### PR TITLE
Rename 'nci' to 'mas' for username and database name

### DIFF
--- a/mas/api/api.go
+++ b/mas/api/api.go
@@ -19,7 +19,7 @@ import (
 var (
 	db        *sql.DB
 	mc        *memcache.Client
-	db_name   = flag.String("database", "nci", "database name")
+	db_name   = flag.String("database", "mas", "database name")
 	db_user   = flag.String("user", "api", "database user name")
 	db_pool   = flag.Int("pool", 8, "database pool size")
 	db_limit  = flag.Int("limit", 64, "database concurrent requests")

--- a/mas/db/ingest.sh
+++ b/mas/db/ingest.sh
@@ -2,5 +2,5 @@
 
 shard=$1
 
-iconv -f ISO-8859-1 -t UTF-8 - | sort | uniq | psql -v ON_ERROR_STOP=1 -A -t -q -d nci \
+iconv -f ISO-8859-1 -t UTF-8 | sort | uniq | psql -v ON_ERROR_STOP=1 -A -t -q -d mas \
   -c "set search_path to ${shard}; copy ingest from stdin with (format 'csv', delimiter E'\\t', quote E'\\b');" >/dev/null

--- a/mas/db/schema.sql
+++ b/mas/db/schema.sql
@@ -15,17 +15,17 @@ set role postgres;
 \c postgres
 
 -- Atomic DDL can't handle a database drop, so kill off active clients
-update pg_database set datallowconn = 'false' where datname = 'nci';
-select pg_terminate_backend(pid) from pg_stat_activity where datname = 'nci';
+update pg_database set datallowconn = 'false' where datname = 'mas';
+select pg_terminate_backend(pid) from pg_stat_activity where datname = 'mas';
 
-drop database if exists nci;
+drop database if exists mas;
 
 do $$
   begin
 
-    if (select true from pg_roles where rolname = 'nci') then
-      drop owned by nci cascade;
-      drop role nci;
+    if (select true from pg_roles where rolname = 'mas') then
+      drop owned by mas cascade;
+      drop role mas;
     end if;
 
     if (select true from pg_roles where rolname = 'api') then
@@ -36,23 +36,23 @@ do $$
   end
 $$;
 
-create role nci with password null;
-create database nci owner nci;
-grant all privileges on database nci to nci;
+create role mas with password null;
+create database mas owner mas;
+grant all privileges on database mas to mas;
 
 create role api with password null login;
-grant connect on database nci to api;
+grant connect on database mas to api;
 
-\c nci
+\c mas
 
 alter default privileges for role postgres in schema public grant select on tables to public;
-alter default privileges for role nci in schema public grant select on tables to public;
+alter default privileges for role mas in schema public grant select on tables to public;
 
 set search_path to public;
 set client_min_messages to warning;
 
 create extension postgis;
-grant all on spatial_ref_sys to nci;
+grant all on spatial_ref_sys to mas;
 
 -- Postgres has no built-in operators for indexing UUID using GIN
 create operator class _uuid_ops default
@@ -67,7 +67,7 @@ create operator class _uuid_ops default
   function 4 ginarrayconsistent(internal, smallint, anyarray, integer, internal, internal, internal, internal),
   storage uuid;
 
-set role nci;
+set role mas;
 
 \i util.sql
 

--- a/mas/db/shard.sql
+++ b/mas/db/shard.sql
@@ -19,7 +19,7 @@
 -- cat <tsv> | parallel -j 8 --pipe -L 100000 --retries 10 --will-cite \
 --   'psql -c "set search_path to ${shard}; copy ingest from stdin with (format 'csv', delimiter E'\t', quote E'\b');"'
 
-set role nci;
+set role mas;
 
 -- Data ingest holding yard
 drop table if exists ingest cascade;

--- a/mas/db/shard_create.sh
+++ b/mas/db/shard_create.sh
@@ -4,13 +4,13 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 shard=$1
 gpath=$2
 
-(cd "$here" && runuser postgres -c 'psql -v ON_ERROR_STOP=1 -A -t -q -d nci' <<EOD
+(cd "$here" && runuser postgres -c 'psql -v ON_ERROR_STOP=1 -A -t -q -d mas' <<EOD
 
-set role nci;
+set role mas;
 create schema if not exists ${shard};
 set search_path to ${shard};
 grant usage on schema ${shard} to public;
-alter default privileges for role nci in schema ${shard} grant select on tables to public;
+alter default privileges for role mas in schema ${shard} grant select on tables to public;
 
 insert into public.shards (sh_code, sh_path)
   values ('${shard}', '${gpath}')

--- a/mas/db/shard_exists.sh
+++ b/mas/db/shard_exists.sh
@@ -3,7 +3,7 @@
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 shard=$1
 
-(cd "$here" && runuser postgres -c 'psql -v ON_ERROR_STOP=1 -A -t -q -d nci' <<EOD
+(cd "$here" && runuser postgres -c 'psql -v ON_ERROR_STOP=1 -A -t -q -d mas' <<EOD
   select true from ${shard}.paths limit 1
 EOD
 )

--- a/mas/db/shard_refresh.sh
+++ b/mas/db/shard_refresh.sh
@@ -3,9 +3,9 @@
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 shard=$1
 
-(cd "$here" && runuser postgres -c 'psql -v ON_ERROR_STOP=1 -A -t -q -d nci' <<EOD
+(cd "$here" && runuser postgres -c 'psql -v ON_ERROR_STOP=1 -A -t -q -d mas' <<EOD
 
-set role nci;
+set role mas;
 set search_path to ${shard};
 
 select refresh_views();

--- a/mas/db/shard_reset.sh
+++ b/mas/db/shard_reset.sh
@@ -3,9 +3,9 @@
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 shard=$1
 
-(cd "$here" && runuser postgres -c 'psql -v ON_ERROR_STOP=1 -A -t -q -d nci' <<EOD
+(cd "$here" && runuser postgres -c 'psql -v ON_ERROR_STOP=1 -A -t -q -d mas' <<EOD
 
-set role nci;
+set role mas;
 set search_path to ${shard};
 
 truncate paths;


### PR DESCRIPTION
The schema and associated shell scripts hardcode `nci` as the PostgreSQL username and database name.  This patch renames all such instances to `mas`. The table names (eg, `nci_foo`) have not yet been dealt with. That will be addressed separately.