### PR TITLE
Remove unreachable code in api.go

### DIFF
--- a/grpc_server/grpc_server.go
+++ b/grpc_server/grpc_server.go
@@ -28,7 +28,7 @@ func (s *server) Process(ctx context.Context, in *pb.GeoRPCGranule) (*pb.Result,
 	errChan := make(chan error)
 	defer close(errChan)
 
-	s.Pool.AddQueue(&pb.Task{in, rChan, errChan})
+	s.Pool.AddQueue(&pb.Task{Payload: in, Resp: rChan, Error: errChan})
 
 	select {
 	case out, ok := <-rChan:

--- a/mas/api/api.go
+++ b/mas/api/api.go
@@ -113,7 +113,6 @@ func main() {
 
 	if err != nil {
 		panic(err)
-		return
 	}
 
 	defer db.Close()

--- a/processor/tile_grpc.go
+++ b/processor/tile_grpc.go
@@ -82,7 +82,7 @@ func getBand(times []time.Time, rasterTime time.Time) (int32, error) {
 			return int32(i + 1), nil
 		}
 	}
-	return -1, fmt.Errorf("%s dataset does not contain Unix date: %d", "Handler", rasterTime)
+	return -1, fmt.Errorf("%s dataset does not contain Unix date: %d", "Handler", rasterTime.Unix())
 }
 
 // ExtractEPSGCode parses an SRS string and gets


### PR DESCRIPTION
I have started running `go vet` over the Go code. Most directories are clean, but there are a few warnings to fix. Here are the first three:

```
$ go vet api.go
api.go:116: unreachable code
$ go vet tile_grpc.go
tile_grpc.go:85: arg rasterTime for printf verb %d of wrong type: time.Time
$ go vet grpc_server.go
grpc_server.go:31: github.com/nci/gsky/grpc_server/gdalservice.Task composite literal uses unkeyed fields
```