### PR TITLE
added netcdf to the supported file format of WCS

### DIFF
--- a/templates/WCS_DescribeCoverage.tpl
+++ b/templates/WCS_DescribeCoverage.tpl
@@ -63,6 +63,7 @@
     </supportedCRSs>
     <supportedFormats>
       <formats>GeoTIFF</formats>
+      <formats>NetCDF</formats>
     </supportedFormats>
     <supportedInterpolations>
       <interpolationMethod>none</interpolationMethod>


### PR DESCRIPTION
@bje- I added netcdf as the supported file format for WCS DescribeCoverage endpoint. This fixed bug https://github.com/nci/gsky/issues/26 Please review and merge the changes.