### PR TITLE
Fix potential context leaks found by go vet

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -203,21 +203,18 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 
 		ctx, ctxCancel := context.WithCancel(ctx)
 		errChan := make(chan error)
-		//start := time.Now()
 		tp := proc.InitTilePipeline(ctx, config.ServiceConfig.MASAddress, LoadBalance(config.ServiceConfig.WorkerNodes), errChan)
-		//log.Println("Pipeline Init Time", time.Since(start))
 		select {
 		case res := <-tp.Process(geoReq):
 			w.Write(res)
-			//log.Println("Pipeline Total Time", time.Since(start))
 		case err := <-errChan:
-			ctxCancel()
 			Info.Printf("Error in the pipeline: %v\n", err)
 			http.Error(w, err.Error(), 500)
 		case <-ctx.Done():
 			Error.Printf("Context cancelled with message: %v\n", ctx.Err())
 			http.Error(w, ctx.Err().Error(), 500)
 		}
+		ctxCancel()
 		return
 
 	case "GetLegendGraphic":
@@ -343,10 +340,12 @@ func serveWPS(ctx context.Context, params utils.WPSParams, conf *utils.Config, r
 				return
 			case <-ctx.Done():
 				Error.Printf("Context cancelled with message: %v\n", ctx.Err())
+				ctxCancel()
 				http.Error(w, ctx.Err().Error(), 500)
 				return
 			}
 		}
+		ctxCancel()
 
 		err := utils.ExecuteWriteTemplateFile(w, result,
 			utils.DataDir+"/templates/WPS_Execute.tpl")


### PR DESCRIPTION
Fix potential context leaks found by `go vet`:

```    
the ctxCancel function is not used on all paths (possible context leak)
this return statement may be reached without using the ctxCancel var ...
```

I re-arranged the code slightly from the original attempt to fix this just to minimise the diffs. This one should be simple to review.