### PR TITLE
added conditional check for the existence layer legend path

### DIFF
--- a/templates/WMS_GetCapabilities.tpl
+++ b/templates/WMS_GetCapabilities.tpl
@@ -116,10 +116,12 @@
 					<Name>{{ .Name }}</Name>
 					<Title>{{ .Title }}</Title>
 					<Abstract>A sample style that draws a raster, good for displaying imagery</Abstract>
+					{{if .LegendPath }}
 					<LegendURL width="160" height="424">
 						<Format>image/png</Format>
 						<OnlineResource xlink:type="simple" xlink:href="http://{{ .OWSHostname }}/ows?service=WMS&amp;request=GetLegendGraphic&amp;version=1.3.0&amp;layers={{ .Name }}"/>
 					</LegendURL>
+					{{end}}
 				</Style>
 			</Layer>
 			{{end}}


### PR DESCRIPTION
@bje- I added add conditional check to see if legend path is set is the config file. If not set, we will not send legend in the GetCapabilities call. This fixed https://github.com/nci/gsky/issues/15 and probably https://github.com/nci/gsky/issues/27 Howerver, https://github.com/nci/gsky/issues/27 requires additional testing using QGIS which I do not have at the moment. Please review and merge the changes.