### PR TITLE
removed jpeg and gif format

### DIFF
--- a/templates/WMS_GetCapabilities.tpl
+++ b/templates/WMS_GetCapabilities.tpl
@@ -41,8 +41,6 @@
 			</GetCapabilities>
 			<GetMap>
 				<Format>image/png</Format>
-				<Format>image/gif</Format>
-				<Format>image/jpeg</Format>
 				<DCPType>
 				  <HTTP>
 				    <Get>


### PR DESCRIPTION
@bje- I removed jpeg and gif format for WMS output as the current code doesn't work with them. This fixed https://github.com/nci/gsky/issues/10 Please review and merge the changes.