### PR TITLE
Keep concurrent.c out of the way of the Go source

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -22,11 +22,12 @@ all: concurrent
 	$(GOBUILD) -o accept acceptance_tests/accept.go
 	$(GOBUILD) -o masapi mas/api/api.go
 
-concurrent: concurrent.c
+concurrent: src/concurrent.c
 	$(CC) -Wall -O2 $< -o $@
 
-concurrent.c:
-	wget --quiet https://github.com/seanpringle/concurrent/raw/634330a119f16916e5ad24da32172fa9312ab5a3/concurrent.c
+src/concurrent.c:
+	mkdir -p $(dir $@)
+	wget --quiet https://github.com/seanpringle/concurrent/raw/634330a119f16916e5ad24da32172fa9312ab5a3/concurrent.c -O $@
 
 # Note: install(1) can't deal with directories as source, so use cp -r.
 install:


### PR DESCRIPTION
This change puts `concurrent.c` in a subdirectory out of the way of the Go source code. `go get` (and possibly other tools) complain if `.c` files are in the Go project directory.