### PR TITLE
 added support for multiple config files

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -631,9 +631,6 @@ func owsHandler(w http.ResponseWriter, r *http.Request) {
 	if len(r.URL.Path) > len("/ows/") {
 		namespace = r.URL.Path[len("/ows/"):]
 	}
-	if len(namespace) == 0 {
-		namespace = "."
-	}
 	config, ok := configMap[namespace]
 	if !ok {
 		Info.Printf("Invalid dataset namespace: %v for url: %v\n", namespace, r.URL.Path)

--- a/utils/config.go
+++ b/utils/config.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+	"path/filepath"
 )
 
 var LibexecDir = "/usr/local/libexec"
@@ -227,6 +228,36 @@ func GenerateDates(name string, start, end time.Time, stepMins time.Duration) []
 	return dateGen[name](start, end, stepMins)
 }
 
+func LoadAllConfigFiles(rootDir string) (map[string]*Config, error) {
+	configMap := make(map[string]*Config)
+	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error { 
+    if err != nil {
+      return err
+    }
+
+    if !info.IsDir() && info.Name() == "config.json" {
+      relPath , _:= filepath.Rel(rootDir, filepath.Dir(path))
+      log.Printf("Loading config file: %s under namespace: %s\n", path, relPath)
+
+			config := &Config{}
+			e := config.LoadConfigFile(path)
+			if e != nil {
+				return err
+			}
+
+			configMap[relPath] = config
+    }
+    return nil
+  })
+
+	if len(configMap) == 0 {
+		err = fmt.Errorf("No config file found")
+	}
+
+	return configMap, err
+
+}
+
 // GetConfig marshall the config.json document
 // returning an instance of a Config variable
 // containing all the values
@@ -260,7 +291,7 @@ func (config *Config) LoadConfigFile(configFile string) error {
 	return nil
 }
 
-func (config *Config) Watch(infoLog, errLog *log.Logger) {
+func WatchConfig(infoLog, errLog *log.Logger, configMap *map[string]*Config) {
 	// Catch SIGHUP to automatically reload cache
 	sighup := make(chan os.Signal, 1)
 	signal.Notify(sighup, syscall.SIGHUP)
@@ -268,11 +299,20 @@ func (config *Config) Watch(infoLog, errLog *log.Logger) {
 		select {
 		case <-sighup:
 			infoLog.Println("Caught SIGHUP, reloading config...")
-			err := config.LoadConfigFile(EtcDir + "/config.json")
+			confMap, err := LoadAllConfigFiles(EtcDir)
 			if err != nil {
-				errLog.Printf("%v\n", err)
-				panic(err)
+				errLog.Printf("Error in loading config files: %v\n", err)
+				return
+			}
+
+			for k := range *configMap {
+				delete(*configMap, k)
+			}
+
+			for k := range confMap {
+				(*configMap)[k] = confMap[k]
 			}
 		}
 	}()
 }
+


### PR DESCRIPTION
@bje- I added code to support multiple config files as we brainstormed during the Gsky sprint meeting. Essentially we can access different virtual datasets like this http://gsky-domain-url/ows/geoglam?service .... or http://gsky-domain-url/ows/ga/dea?service .... 
The directory structure of the config files will be like this:
<config_root_dir>/geoglam/config.json
<config_root_dir>/ga/dea/config.json
Each config files can have different layers for different datasets. Please review and merge the changes.