### PR TITLE
added I and J into http request parameters for GetFeatureInfo()

### DIFF
--- a/utils/wms.go
+++ b/utils/wms.go
@@ -116,10 +116,18 @@ func WMSParamsChecker(params map[string][]string, compREMap map[string]*regexp.R
 		}
 	}
 
+	if i, iOK := params["i"]; iOK {
+		params["x"] = i
+	}
+
 	if x, xOK := params["x"]; xOK {
 		if compREMap["x"].MatchString(x[0]) {
 			jsonFields = append(jsonFields, fmt.Sprintf(`"x":%s`, x[0]))
 		}
+	}
+
+	if j, jOK := params["j"]; jOK {
+		params["y"] = j
 	}
 
 	if y, yOK := params["y"]; yOK {


### PR DESCRIPTION
@bje- I added support for I and J http request parameters. I and J in WMS 1.3.0 work in the same way as X and Y in WMS 1.1.1 so I simply convert them into X and Y if they're present. This should fix https://github.com/nci/gsky/issues/14