### PR TITLE
Fix more 'go lint' warnings

### DIFF
--- a/grpc_server/gdalprocess/warp.go
+++ b/grpc_server/gdalprocess/warp.go
@@ -42,9 +42,9 @@ import (
 	"reflect"
 )
 
-const SIZE_OF_UINT16 = 2
-const SIZE_OF_INT16 = 2
-const SIZE_OF_FLOAT32 = 4
+const SizeofUint16 = 2
+const SizeofInt16 = 2
+const SizeofFloat32 = 4
 
 var GDALTypes = map[C.GDALDataType]string{0: "Unkown", 1: "Byte", 2: "UInt16", 3: "Int16",
 	4: "UInt32", 5: "Int32", 6: "Float32", 7: "Float64",
@@ -69,8 +69,8 @@ func initNoDataSlice(rType string, noDataValue float64, ssize int32) []uint8 {
 			out[i] = fill
 		}
 		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&out))
-		headr.Len *= SIZE_OF_INT16
-		headr.Cap *= SIZE_OF_INT16
+		headr.Len *= SizeofInt16
+		headr.Cap *= SizeofInt16
 		return *(*[]uint8)(unsafe.Pointer(&headr))
 	case "UInt16":
 		out := make([]uint16, size)
@@ -79,8 +79,8 @@ func initNoDataSlice(rType string, noDataValue float64, ssize int32) []uint8 {
 			out[i] = fill
 		}
 		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&out))
-		headr.Len *= SIZE_OF_UINT16
-		headr.Cap *= SIZE_OF_UINT16
+		headr.Len *= SizeofUint16
+		headr.Cap *= SizeofUint16
 		return *(*[]uint8)(unsafe.Pointer(&headr))
 	case "Float32":
 		out := make([]float32, size)
@@ -89,8 +89,8 @@ func initNoDataSlice(rType string, noDataValue float64, ssize int32) []uint8 {
 			out[i] = fill
 		}
 		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&out))
-		headr.Len *= SIZE_OF_FLOAT32
-		headr.Cap *= SIZE_OF_FLOAT32
+		headr.Len *= SizeofFloat32
+		headr.Cap *= SizeofFloat32
 		return *(*[]uint8)(unsafe.Pointer(&headr))
 	default:
 		return []uint8{}

--- a/processor/tile_merger.go
+++ b/processor/tile_merger.go
@@ -11,9 +11,9 @@ import (
 	"unsafe"
 )
 
-const SIZE_OF_UINT16 = 2
-const SIZE_OF_INT16 = 2
-const SIZE_OF_FLOAT32 = 4
+const SizeofUint16 = 2
+const SizeofInt16 = 2
+const SizeofFloat32 = 4
 
 type RasterMerger struct {
 	In    chan *FlexRaster
@@ -56,13 +56,13 @@ func MergeMaskedRaster(r *FlexRaster, canvasMap map[string]*FlexRaster, mask []b
 		}
 	case "Int16":
 		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&canvasMap[r.NameSpace].Data))
-		headr.Len /= SIZE_OF_INT16
-		headr.Cap /= SIZE_OF_INT16
+		headr.Len /= SizeofInt16
+		headr.Cap /= SizeofInt16
 		canvas := *(*[]int16)(unsafe.Pointer(&headr))
 
 		header := *(*reflect.SliceHeader)(unsafe.Pointer(&r.Data))
-		header.Len /= SIZE_OF_INT16
-		header.Cap /= SIZE_OF_INT16
+		header.Len /= SizeofInt16
+		header.Cap /= SizeofInt16
 		data := *(*[]int16)(unsafe.Pointer(&header))
 		nodata := int16(r.NoData)
 
@@ -82,13 +82,13 @@ func MergeMaskedRaster(r *FlexRaster, canvasMap map[string]*FlexRaster, mask []b
 		}
 	case "UInt16":
 		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&canvasMap[r.NameSpace].Data))
-		headr.Len /= SIZE_OF_UINT16
-		headr.Cap /= SIZE_OF_UINT16
+		headr.Len /= SizeofUint16
+		headr.Cap /= SizeofUint16
 		canvas := *(*[]uint16)(unsafe.Pointer(&headr))
 
 		header := *(*reflect.SliceHeader)(unsafe.Pointer(&r.Data))
-		header.Len /= SIZE_OF_UINT16
-		header.Cap /= SIZE_OF_UINT16
+		header.Len /= SizeofUint16
+		header.Cap /= SizeofUint16
 		data := *(*[]uint16)(unsafe.Pointer(&header))
 		nodata := uint16(r.NoData)
 
@@ -108,13 +108,13 @@ func MergeMaskedRaster(r *FlexRaster, canvasMap map[string]*FlexRaster, mask []b
 		}
 	case "Float32":
 		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&canvasMap[r.NameSpace].Data))
-		headr.Len /= SIZE_OF_FLOAT32
-		headr.Cap /= SIZE_OF_FLOAT32
+		headr.Len /= SizeofFloat32
+		headr.Cap /= SizeofFloat32
 		canvas := *(*[]float32)(unsafe.Pointer(&headr))
 
 		header := *(*reflect.SliceHeader)(unsafe.Pointer(&r.Data))
-		header.Len /= SIZE_OF_FLOAT32
-		header.Cap /= SIZE_OF_FLOAT32
+		header.Len /= SizeofFloat32
+		header.Cap /= SizeofFloat32
 		data := *(*[]float32)(unsafe.Pointer(&header))
 		nodata := float32(r.NoData)
 
@@ -155,8 +155,8 @@ func initNoDataSlice(rType string, noDataValue float64, size int) []uint8 {
 			out[i] = fill
 		}
 		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&out))
-		headr.Len *= SIZE_OF_INT16
-		headr.Cap *= SIZE_OF_INT16
+		headr.Len *= SizeofInt16
+		headr.Cap *= SizeofInt16
 		return *(*[]uint8)(unsafe.Pointer(&headr))
 	case "UInt16":
 		out := make([]uint16, size)
@@ -165,8 +165,8 @@ func initNoDataSlice(rType string, noDataValue float64, size int) []uint8 {
 			out[i] = fill
 		}
 		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&out))
-		headr.Len *= SIZE_OF_UINT16
-		headr.Cap *= SIZE_OF_UINT16
+		headr.Len *= SizeofUint16
+		headr.Cap *= SizeofUint16
 		return *(*[]uint8)(unsafe.Pointer(&headr))
 	case "Float32":
 		out := make([]float32, size)
@@ -175,8 +175,8 @@ func initNoDataSlice(rType string, noDataValue float64, size int) []uint8 {
 			out[i] = fill
 		}
 		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&out))
-		headr.Len *= SIZE_OF_FLOAT32
-		headr.Cap *= SIZE_OF_FLOAT32
+		headr.Len *= SizeofFloat32
+		headr.Cap *= SizeofFloat32
 		return *(*[]uint8)(unsafe.Pointer(&headr))
 	default:
 		return []uint8{}
@@ -228,8 +228,8 @@ func ComputeMask(mask *utils.Mask, data []byte, rType string) (out []bool, err e
 			}
 		}
 	case "Int16":
-		header.Len /= SIZE_OF_INT16
-		header.Cap /= SIZE_OF_INT16
+		header.Len /= SizeofInt16
+		header.Cap /= SizeofInt16
 		data := *(*[]int16)(unsafe.Pointer(&header))
 		out = make([]bool, len(data))
 		maskValue64, _ := strconv.ParseInt(mask.Value, 2, 16)
@@ -240,8 +240,8 @@ func ComputeMask(mask *utils.Mask, data []byte, rType string) (out []bool, err e
 			}
 		}
 	case "UInt16":
-		header.Len /= SIZE_OF_UINT16
-		header.Cap /= SIZE_OF_UINT16
+		header.Len /= SizeofUint16
+		header.Cap /= SizeofUint16
 		data := *(*[]uint16)(unsafe.Pointer(&header))
 		out = make([]bool, len(data))
 		maskValue64, _ := strconv.ParseUint(mask.Value, 2, 16)
@@ -290,13 +290,13 @@ func (enc *RasterMerger) Run() {
 
 	if len(canvasMap) == 2 && canvasMap["Nadir_Reflectance_Band1"].Type == "Int16" {
 		headerB1 := *(*reflect.SliceHeader)(unsafe.Pointer(&canvasMap["Nadir_Reflectance_Band1"].Data))
-		headerB1.Len /= SIZE_OF_INT16
-		headerB1.Cap /= SIZE_OF_INT16
+		headerB1.Len /= SizeofInt16
+		headerB1.Cap /= SizeofInt16
 		DataB1 := *(*[]int16)(unsafe.Pointer(&headerB1))
 
 		headerB2 := *(*reflect.SliceHeader)(unsafe.Pointer(&canvasMap["Nadir_Reflectance_Band2"].Data))
-		headerB2.Len /= SIZE_OF_INT16
-		headerB2.Cap /= SIZE_OF_INT16
+		headerB2.Len /= SizeofInt16
+		headerB2.Cap /= SizeofInt16
 		DataB2 := *(*[]int16)(unsafe.Pointer(&headerB2))
 
 		nodata := float32(canvasMap["Nadir_Reflectance_Band1"].NoData)
@@ -338,22 +338,22 @@ func (enc *RasterMerger) Run() {
 				Height: canvas.Height, Width: canvas.Width, OffX: canvas.OffX, OffY: canvas.OffY,
 				NameSpace: canvas.NameSpace}
 		case "UInt16":
-			headr.Len /= SIZE_OF_UINT16
-			headr.Cap /= SIZE_OF_UINT16
+			headr.Len /= SizeofUint16
+			headr.Cap /= SizeofUint16
 			data := *(*[]uint16)(unsafe.Pointer(&headr))
 			enc.Out <- &UInt16Raster{ConfigPayLoad: canvas.ConfigPayLoad, NoData: canvas.NoData, Data: data,
 				Height: canvas.Height, Width: canvas.Width, OffX: canvas.OffX, OffY: canvas.OffY,
 				NameSpace: canvas.NameSpace}
 		case "Int16":
-			headr.Len /= SIZE_OF_INT16
-			headr.Cap /= SIZE_OF_INT16
+			headr.Len /= SizeofInt16
+			headr.Cap /= SizeofInt16
 			data := *(*[]int16)(unsafe.Pointer(&headr))
 			enc.Out <- &Int16Raster{ConfigPayLoad: canvas.ConfigPayLoad, NoData: canvas.NoData, Data: data,
 				Height: canvas.Height, Width: canvas.Width, OffX: canvas.OffX, OffY: canvas.OffY,
 				NameSpace: canvas.NameSpace}
 		case "Float32":
-			headr.Len /= SIZE_OF_FLOAT32
-			headr.Cap /= SIZE_OF_FLOAT32
+			headr.Len /= SizeofFloat32
+			headr.Cap /= SizeofFloat32
 			data := *(*[]float32)(unsafe.Pointer(&headr))
 			enc.Out <- &Float32Raster{ConfigPayLoad: canvas.ConfigPayLoad, NoData: canvas.NoData, Data: data,
 				Height: canvas.Height, Width: canvas.Width, OffX: canvas.OffX, OffY: canvas.OffY,


### PR DESCRIPTION
Fixes:

```
tile_merger.go:14:7: don't use ALL_CAPS in Go names; use CamelCase
tile_merger.go:15:7: don't use ALL_CAPS in Go names; use CamelCase
tile_merger.go:16:7: don't use ALL_CAPS in Go names; use CamelCase
warp.go:45:7: don't use ALL_CAPS in Go names; use CamelCase
warp.go:46:7: don't use ALL_CAPS in Go names; use CamelCase
warp.go:47:7: don't use ALL_CAPS in Go names; use CamelCase
```