### PR TITLE
changed to use last known date if time not specified

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -150,12 +150,12 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			return
 		}
 		if params.Time == nil {
-			firstTime, err := time.Parse(utils.ISOFormat, conf.Layers[idx].Dates[0])
+			currentTime, err := time.Parse(utils.ISOFormat, conf.Layers[idx].Dates[len(conf.Layers[idx].Dates)-1])
 			if err != nil {
 				http.Error(w, fmt.Sprintf("Cannot find a valid date to proceed with the request: %s", reqURL), 400)
 				return
 			}
-			params.Time = &firstTime
+			params.Time = &currentTime
 		}
 		if params.CRS == nil {
 			http.Error(w, fmt.Sprintf("Request %s should contain a valid ISO 'crs/srs' parameter.", reqURL), 400)
@@ -336,12 +336,12 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 		}
 
 		if params.Time == nil {
-			firstTime, err := time.Parse(utils.ISOFormat, conf.Layers[idx].Dates[0])
+			currentTime, err := time.Parse(utils.ISOFormat, conf.Layers[idx].Dates[len(conf.Layers[idx].Dates)-1])
 			if err != nil {
 				http.Error(w, fmt.Sprintf("Cannot find a valid date to proceed with the request: %s", reqURL), 400)
 				return
 			}
-			params.Time = &firstTime
+			params.Time = &currentTime
 		}
 		if params.CRS == nil {
 			http.Error(w, fmt.Sprintf("Request %s should contain a valid ISO 'crs/srs' parameter.", reqURL), 400)


### PR DESCRIPTION
@bje- If time is not specified in the http request, we now use last known date instead of first known date in order to be standard compliant. This fixed https://github.com/nci/gsky/issues/12 Please review and merge the changes.