### PR TITLE
Add 'distclean' make target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -51,3 +51,7 @@ install:
 
 clean:
 	-rm -f accept gsky-crawl gsky-gdal-process gsky-ows gsky-rpc masapi concurrent
+
+distclean: clean
+	-rm -f Makefile config.log config.status
+	-rm -r src


### PR DESCRIPTION
It's customary for Autoconfiscated projects to have a `distclean` target that does more than `clean`, such as deleting the files `config.log`, `config.status` and the generated `Makefile`. This patch adds such a target for convenience.