### PR TITLE
added current="True" attribute to WMS GetCaps

### DIFF
--- a/templates/WMS_GetCapabilities.tpl
+++ b/templates/WMS_GetCapabilities.tpl
@@ -99,7 +99,7 @@
 				</EX_GeographicBoundingBox>
 				<BoundingBox CRS="CRS:84" minx="-180.0" miny="-90.0" maxx="180.0" maxy="90.0"/>
 				<BoundingBox CRS="EPSG:4326" minx="-90.0" miny="-180.0" maxx="90.0" maxy="180.0"/>
-				<Dimension name="time" default="current" units="ISO8601">{{ range $index, $value := .Dates }}{{if $index}},{{end}}{{ $value }}{{ end }}</Dimension>
+				<Dimension name="time" default="current" current="True" units="ISO8601">{{ range $index, $value := .Dates }}{{if $index}},{{end}}{{ $value }}{{ end }}</Dimension>
 				<MetadataURL type="ISO19115:2003">
 					<Format>text/plain</Format>
 					<OnlineResource xlink:type="simple" xlink:href="{{ .MetadataURL }}"/>


### PR DESCRIPTION
@bje- I added current="True" attribute to WMS GetCaps. This fixed https://github.com/nci/gsky/issues/16. A side note: we don't have to add code to explicitly handle time=current in the GetMap operation because time=current will fail http parameter validation https://github.com/nci/gsky/blob/master/utils/wms.go#L49 which leaves params["time"] unset. If params["time"] is unset, GSKY will use the latest time https://github.com/nci/gsky/blob/master/ows.go#L153 which conforms with the standard. Please review and merge the changes.