### PR TITLE
Makefile fix: pass -std=c99 to gcc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -25,7 +25,7 @@ all: concurrent
 	$(GOBUILD) -o masapi mas/api/api.go
 
 concurrent: src/concurrent.c
-	$(CC) -Wall -O2 $< -o $@
+	$(CC) -std=c99 -Wall -O2 $< -o $@
 
 src/concurrent.c:
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Older versions of `gcc` do not default to C99. The `concurrent.c` code uses C99 features, so we need to pass `-std=c99`.