### PR TITLE
Makefile tweaks

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -14,6 +14,10 @@ LDFLAGS="-X=$(PKGROOT)/utils.LibexecDir=${libexecdir} -X=$(PKGROOT)/grpc_server/
 	-X=$(PKGROOT)/utils.EtcDir=$(sysconfdir) -X=$(PKGROOT)/utils.DataDir=${datarootdir}/gsky"
 GOBUILD = CGO_CFLAGS=$(CGO_CFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) go build -ldflags=$(LDFLAGS)
 GOGET = CGO_CFLAGS=$(CGO_CFLAGS) go get
+GOBIN=$(shell go env GOBIN)
+ifeq ($(strip $(GOBIN)),)
+  GOBIN=$(shell go env GOPATH)/bin
+endif
 
 all: concurrent
 	$(GOGET)

--- a/Makefile.in
+++ b/Makefile.in
@@ -7,13 +7,13 @@ sysconfdir = @sysconfdir@
 srcdir = @srcdir@
 VPATH = @srcdir@
 
-PKGROOT=github.com/nci/gsky
+BASEPATH=github.com/nci/gsky
 CGO_CFLAGS="@CGO_CFLAGS@"
 CGO_LDFLAGS=-lgdal
-LDFLAGS="-X=$(PKGROOT)/utils.LibexecDir=${libexecdir} -X=$(PKGROOT)/grpc_server/gdalservice.LibexecDir=${libexecdir} \
-	-X=$(PKGROOT)/utils.EtcDir=$(sysconfdir) -X=$(PKGROOT)/utils.DataDir=${datarootdir}/gsky"
 GOBUILD = CGO_CFLAGS=$(CGO_CFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) go build -ldflags=$(LDFLAGS)
 GOGET = CGO_CFLAGS=$(CGO_CFLAGS) go get
+LDFLAGS="-X=$(BASEPATH)/utils.LibexecDir=${libexecdir} -X=$(BASEPATH)/grpc_server/gdalservice.LibexecDir=${libexecdir} \
+	-X=$(BASEPATH)/utils.EtcDir=$(sysconfdir) -X=$(BASEPATH)/utils.DataDir=${datarootdir}/gsky"
 GOBIN=$(shell go env GOBIN)
 ifeq ($(strip $(GOBIN)),)
   GOBIN=$(shell go env GOPATH)/bin


### PR DESCRIPTION
There are two preparatory changes here:

*  Set a Make variable `$(GOBIN)` by running `go path GOBIN` and, if that is empty, runs `go path GOPATH` and appends `/bin`.

* Renames `$(PKGROOT)` to `$(BASEPATH)` for clarity.