### PR TITLE
added check for existing error before claiming no config file found

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -249,7 +249,7 @@ func LoadAllConfigFiles(rootDir string) (map[string]*Config, error) {
 		return nil
 	})
 
-	if len(configMap) == 0 {
+	if err == nil && len(configMap) == 0 {
 		err = fmt.Errorf("No config file found")
 	}
 


### PR DESCRIPTION
@bje- I added check for existing error before claiming no config file found. If we don't have this check and there is a parsing error in the first config file, we will have no entry in configMap and the code will return "no config file found" instead of the parsing error message. Please review and merge the changes.