### PR TITLE
changed timestamp sorting into decsending order

### DIFF
--- a/processor/tile_merger.go
+++ b/processor/tile_merger.go
@@ -192,7 +192,7 @@ func ProcessRasterStack(rasterStack map[int64][]*FlexRaster, maskMap map[int64][
 	for k := range rasterStack {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	sort.Slice(keys, func(i, j int) bool { return keys[i] > keys[j] })
 
 	for _, geoStamp := range keys {
 		for _, r := range rasterStack[geoStamp] {


### PR DESCRIPTION
@bje- As discussed with @monkeybutter ,the original timestamp sorting order on line 195 of tile_merger.go was in ascending order and this causes the block of if statement on line 44 never being executed. In addition, it is more reasonable to fill the missing pixels using the image data as latest as as possible. Therefore, it makes more sense to change the sorting order into descending order.