### PR TITLE
Add support for Go testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,6 @@ script:
   - go tool vet $TRAVIS_BUILD_DIR
   # Ensure that gofmt -d produces zero diff output
   - test -z "$(gofmt -d $TRAVIS_BUILD_DIR)"
-  - go test github.com/$TRAVIS_REPO_SLUG
+  - ./configure
+  - make all
+  - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
   - go tool vet $TRAVIS_BUILD_DIR
   # Ensure that gofmt -d produces zero diff output
   - test -z "$(gofmt -d $TRAVIS_BUILD_DIR)"
-  - ./configure
-  - make check
+  - cd $TRAVIS_BUILD_DIR && ./configure
+  - cd $TRAVIS_BUILD_DIR && make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,4 @@ script:
   # Ensure that gofmt -d produces zero diff output
   - test -z "$(gofmt -d $TRAVIS_BUILD_DIR)"
   - ./configure
-  - make all
   - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ script:
   - go tool vet $TRAVIS_BUILD_DIR
   # Ensure that gofmt -d produces zero diff output
   - test -z "$(gofmt -d $TRAVIS_BUILD_DIR)"
+  - go test github.com/$TRAVIS_REPO_SLUG

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,3 @@ script:
   - go tool vet $TRAVIS_BUILD_DIR
   # Ensure that gofmt -d produces zero diff output
   - test -z "$(gofmt -d $TRAVIS_BUILD_DIR)"
-  - cd $TRAVIS_BUILD_DIR && ./configure
-  - cd $TRAVIS_BUILD_DIR && make check

--- a/Makefile.in
+++ b/Makefile.in
@@ -29,6 +29,9 @@ all: concurrent
 	$(GOBUILD) -o accept acceptance_tests/accept.go
 	$(GOBUILD) -o masapi mas/api/api.go
 
+check test:
+	go test
+
 concurrent: src/concurrent.c
 	$(CC) -std=c99 -Wall -O2 $< -o $@
 

--- a/grpc_server/gdalservice/pool.go
+++ b/grpc_server/gdalservice/pool.go
@@ -6,7 +6,7 @@ import (
 	"log"
 )
 
-var LibexecDir = "/usr/local/libexec"
+var LibexecDir = "."
 
 type ProcessPool struct {
 	Pool      []*Process

--- a/ows_test.go
+++ b/ows_test.go
@@ -1,0 +1,8 @@
+package main
+
+import "testing"
+
+// From little things, big things grow.
+func TestFirst(t *testing.T) {
+  // pass
+}

--- a/ows_test.go
+++ b/ows_test.go
@@ -4,5 +4,5 @@ import "testing"
 
 // From little things, big things grow.
 func TestFirst(t *testing.T) {
-  // pass
+	// pass
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -13,9 +13,9 @@ import (
 	"time"
 )
 
-var LibexecDir = "/usr/local/libexec"
-var EtcDir = "/usr/local/etc"
-var DataDir = "/usr/local/share"
+var LibexecDir = "."
+var EtcDir = "."
+var DataDir = "."
 
 type ServiceConfig struct {
 	OWSHostname string   `json:"ows_hostname"`


### PR DESCRIPTION
This patch introduces a trivial testsuite and the `Makefile` changes for `make check` (or `make test`). We can then activate Go testing in Travis CI.

The change also modifies the built-in paths to "." so that GSKY can be run from the source tree, not requiring `make install`.