### PR TITLE
Clean up Go imports

### DIFF
--- a/acceptance_tests/accept.go
+++ b/acceptance_tests/accept.go
@@ -4,13 +4,14 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	proc "github.com/nci/gsky/processor"
-	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"time"
+
+	proc "github.com/nci/gsky/processor"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var wmsCaps = "http://%s/ows?service=WMS&version=1.3.0&request=GetCapabilities"

--- a/crawl/crawl.go
+++ b/crawl/crawl.go
@@ -3,9 +3,10 @@ package main
 import (
 	"bufio"
 	"encoding/json"
-	extr "github.com/nci/gsky/crawl/extractor"
 	"log"
 	"os"
+
+	extr "github.com/nci/gsky/crawl/extractor"
 )
 
 func ensure(err error) {

--- a/grpc-server/main.go
+++ b/grpc-server/main.go
@@ -3,13 +3,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	pb "github.com/nci/gsky/worker/gdalservice"
 	"log"
 	"net"
 
+	pb "github.com/nci/gsky/worker/gdalservice"
+
+	_ "net/http/pprof"
+
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	_ "net/http/pprof"
 	//"time"
 	"net/http"
 	"os"

--- a/mas/api/api.go
+++ b/mas/api/api.go
@@ -10,10 +10,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/bradfitz/gomemcache/memcache"
-	_ "github.com/lib/pq"
 	"log"
 	"net/http"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	_ "github.com/lib/pq"
 )
 
 var (

--- a/ows.go
+++ b/ows.go
@@ -31,8 +31,9 @@ import (
 	proc "github.com/nci/gsky/processor"
 	"github.com/nci/gsky/utils"
 
-	geo "bitbucket.org/monkeyforecaster/geometry"
 	_ "net/http/pprof"
+
+	geo "bitbucket.org/monkeyforecaster/geometry"
 )
 
 // Global variable to hold the values specified

--- a/processor/drill_indexer.go
+++ b/processor/drill_indexer.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	geo "bitbucket.org/monkeyforecaster/geometry"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	geo "bitbucket.org/monkeyforecaster/geometry"
 )
 
 // string used to format Go ISO times

--- a/processor/drill_merger.go
+++ b/processor/drill_merger.go
@@ -2,9 +2,10 @@ package processor
 
 import (
 	"fmt"
-	pb "github.com/nci/gsky/worker/gdalservice"
 	"math"
 	"sort"
+
+	pb "github.com/nci/gsky/worker/gdalservice"
 )
 
 type DrillMerger struct {

--- a/processor/drill_types.go
+++ b/processor/drill_types.go
@@ -1,9 +1,10 @@
 package processor
 
 import (
-	pb "github.com/nci/gsky/worker/gdalservice"
 	"image"
 	"time"
+
+	pb "github.com/nci/gsky/worker/gdalservice"
 )
 
 type GeoDrillRequest struct {

--- a/processor/palette.go
+++ b/processor/palette.go
@@ -1,8 +1,9 @@
 package processor
 
 import (
-	"github.com/nci/gsky/utils"
 	"image/color"
+
+	"github.com/nci/gsky/utils"
 )
 
 // InterpolateUint8 interpolates the value of a

--- a/processor/tile_grpc.go
+++ b/processor/tile_grpc.go
@@ -2,12 +2,13 @@ package processor
 
 import (
 	"fmt"
-	pb "github.com/nci/gsky/worker/gdalservice"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"log"
 	"strconv"
 	"time"
+
+	pb "github.com/nci/gsky/worker/gdalservice"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 )
 
 type GeoRasterGRPC struct {

--- a/processor/tile_internal_pipeline.go
+++ b/processor/tile_internal_pipeline.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"fmt"
+
 	"github.com/nci/gsky/utils"
 )
 

--- a/processor/tile_merger.go
+++ b/processor/tile_merger.go
@@ -2,13 +2,14 @@ package processor
 
 import (
 	"fmt"
-	"github.com/nci/gsky/utils"
 	"hash/fnv"
 	"reflect"
 	"sort"
 	"strconv"
 	"time"
 	"unsafe"
+
+	"github.com/nci/gsky/utils"
 )
 
 const SizeofUint16 = 2

--- a/processor/tile_pipeline.go
+++ b/processor/tile_pipeline.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+
 	"github.com/nci/gsky/utils"
 )
 

--- a/processor/tile_proc_packed.go
+++ b/processor/tile_proc_packed.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"fmt"
+
 	"github.com/nci/gsky/utils"
 	"golang.org/x/net/context"
 )

--- a/processor/tile_types.go
+++ b/processor/tile_types.go
@@ -1,8 +1,9 @@
 package processor
 
 import (
-	"github.com/nci/gsky/utils"
 	"time"
+
+	"github.com/nci/gsky/utils"
 )
 
 type ScaleParams struct {

--- a/utils/wps.go
+++ b/utils/wps.go
@@ -7,7 +7,6 @@ package utils
 import "C"
 
 import (
-	geo "bitbucket.org/monkeyforecaster/geometry"
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
@@ -15,6 +14,8 @@ import (
 	"io"
 	"regexp"
 	"strings"
+
+	geo "bitbucket.org/monkeyforecaster/geometry"
 )
 
 type Data struct {

--- a/worker/gdalprocess/drill.go
+++ b/worker/gdalprocess/drill.go
@@ -17,8 +17,9 @@ import (
 	"math"
 	"unsafe"
 
-	geo "bitbucket.org/monkeyforecaster/geometry"
 	"encoding/json"
+
+	geo "bitbucket.org/monkeyforecaster/geometry"
 	pb "github.com/nci/gsky/worker/gdalservice"
 )
 

--- a/worker/gdalprocess/warp.go
+++ b/worker/gdalprocess/warp.go
@@ -38,8 +38,9 @@ import (
 	"log"
 	"unsafe"
 
-	pb "github.com/nci/gsky/worker/gdalservice"
 	"reflect"
+
+	pb "github.com/nci/gsky/worker/gdalservice"
 )
 
 const SizeofUint16 = 2

--- a/worker/gdalservice/process.go
+++ b/worker/gdalservice/process.go
@@ -14,9 +14,10 @@ import (
 
 	"bufio"
 	"bytes"
-	"github.com/golang/protobuf/proto"
 	"io"
 	"log"
+
+	"github.com/golang/protobuf/proto"
 )
 
 type ErrorMsg struct {


### PR DESCRIPTION
This patch is the result of running `goimports -w` over the GSKY tree.