### PR TITLE
[v1.0] Makefile.in: Test packages in the current directory and subdirectories

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -23,7 +23,7 @@ all: concurrent
 	CGO_CFLAGS=$(CGO_CFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) go install -ldflags=$(LDFLAGS) ./...
 
 check test:
-	go test
+	go test ./...
 
 concurrent: src/concurrent.c
 	$(CC) -std=c99 -Wall -O2 $< -o $@


### PR DESCRIPTION
This change backports the `go test` fix to the `v1.0` branch.