### PR TITLE
[v1.0] Further clean up and simplify the configure glue

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -10,7 +10,6 @@ VPATH = @srcdir@
 
 BASEPATH=github.com/nci/gsky
 CGO_CFLAGS="@CGO_CFLAGS@"
-CGO_LDFLAGS=-lgdal
 LDFLAGS="-X=$(BASEPATH)/utils.LibexecDir=${libexecdir} -X=$(BASEPATH)/worker/gdalservice.LibexecDir=${libexecdir} \
 	-X=$(BASEPATH)/utils.EtcDir=$(sysconfdir) -X=$(BASEPATH)/utils.DataDir=${datarootdir}/gsky"
 GOBIN=$(shell go env GOBIN)
@@ -20,10 +19,10 @@ endif
 
 all: concurrent
 	CGO_CFLAGS=$(CGO_CFLAGS) go get ./...
-	CGO_CFLAGS=$(CGO_CFLAGS) CGO_LDFLAGS=$(CGO_LDFLAGS) go install -ldflags=$(LDFLAGS) ./...
+	CGO_CFLAGS=$(CGO_CFLAGS) go install -ldflags=$(LDFLAGS) ./...
 
 check test:
-	go test ./...
+	CGO_CFLAGS=$(CGO_CFLAGS) go test ./...
 
 concurrent: src/concurrent.c
 	$(CC) -std=c99 -Wall -O2 $< -o $@

--- a/configure
+++ b/configure
@@ -1250,7 +1250,7 @@ if test -n "$ac_init_help"; then
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-gdal[=DIR]       location of GDAL library [default: /usr/local]
+  --with-gdal[=DIR]       location of GDAL library [default: /usr]
 
 Report bugs to the package provider.
 _ACEOF
@@ -1686,14 +1686,12 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 if test "${with_gdal+set}" = set; then :
   withval=$with_gdal;
 else
-  with_gdal=yes
+  with_gdal=/usr
 fi
 
 
-if test "x$with_gdal" != xyes; then :
-  CGO_CFLAGS="-I$with_gdal/include -L$with_gdal/lib"
+CGO_CFLAGS="-I$with_gdal/include -L$with_gdal/lib -Wl,-rpath-link=$with_gdal/lib"
 
-fi
 
 ac_config_files="$ac_config_files Makefile"
 

--- a/configure.ac
+++ b/configure.ac
@@ -4,11 +4,11 @@ AC_INIT(GSKY, 1.0)
 
 AC_ARG_WITH([gdal],
 	    [AS_HELP_STRING([--with-gdal@<:@=DIR@:>@],
-            [location of GDAL library @<:@default: /usr/local@:>@])],
+            [location of GDAL library @<:@default: /usr@:>@])],
             [],
-            [with_gdal=yes])
+            [with_gdal=/usr])
 
-AS_IF([test "x$with_gdal" != xyes],
-	    AC_SUBST(CGO_CFLAGS, "-I$with_gdal/include -L$with_gdal/lib"))
+CGO_CFLAGS="-I$with_gdal/include -L$with_gdal/lib -Wl,-rpath-link=$with_gdal/lib"
+AC_SUBST(CGO_CFLAGS)
 
 AC_OUTPUT(Makefile)


### PR DESCRIPTION
*Backport to v1.0 branch*

This change further cleans up and simplifies the configure glue.

- Eliminate the CGO_LDFLAGS substitution and Make variable -- we don't need to pass anything to ld(1) specifically, but some linker flags do need to be passed via the compiler driver, so they should be appended to CGO_CFLAGS instead. Most cgo directives are embedded in the .go files.
- Pass CGO_CFLAGS to go test so that it works fully.
- Set default --with-gdal value to /usr so that we use the system GDAL library if the user does not pass a --with-gdal option to configure.