### PR TITLE
[v1.0] Simplify build using pkg-config

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,7 +9,6 @@ srcdir = @srcdir@
 VPATH = @srcdir@
 
 BASEPATH=github.com/nci/gsky
-CGO_CFLAGS="@CGO_CFLAGS@"
 LDFLAGS="-X=$(BASEPATH)/utils.LibexecDir=${libexecdir} -X=$(BASEPATH)/worker/gdalservice.LibexecDir=${libexecdir} \
 	-X=$(BASEPATH)/utils.EtcDir=$(sysconfdir) -X=$(BASEPATH)/utils.DataDir=${datarootdir}/gsky"
 GOBIN=$(shell go env GOBIN)
@@ -17,12 +16,12 @@ ifeq ($(strip $(GOBIN)),)
   GOBIN=$(shell go env GOPATH)/bin
 endif
 
-all: concurrent
-	CGO_CFLAGS=$(CGO_CFLAGS) go get ./...
-	CGO_CFLAGS=$(CGO_CFLAGS) go install -ldflags=$(LDFLAGS) ./...
+all: concurrent pkg-config
+	go get ./...
+	go install -ldflags=$(LDFLAGS) ./...
 
-check test:
-	CGO_CFLAGS=$(CGO_CFLAGS) go test ./...
+check test: pkg-config
+	go test ./...
 
 concurrent: src/concurrent.c
 	$(CC) -std=c99 -Wall -O2 $< -o $@
@@ -50,10 +49,14 @@ install:
 	for f in $(srcdir)/mas/db/*.sql ; do install -m 644 $$f $(datarootdir)/mas ; done
 	for f in $(srcdir)/mas/db/*.sh ; do install -m 755 $$f $(datarootdir)/mas ; done
 
-clean:
+clean: pkg-config
 	go clean -i ./...
 	rm -f concurrent
 
 distclean: clean
 	-rm -f Makefile config.log config.status
 	-rm -r src
+
+.PHONY: pkg-config
+pkg-config:
+	pkg-config --exists gdal

--- a/configure
+++ b/configure
@@ -583,7 +583,6 @@ PACKAGE_URL=''
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
-CGO_CFLAGS
 target_alias
 host_alias
 build_alias
@@ -626,7 +625,6 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
-with_gdal
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1247,11 +1245,6 @@ if test -n "$ac_init_help"; then
    esac
   cat <<\_ACEOF
 
-Optional Packages:
-  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
-  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-gdal[=DIR]       location of GDAL library [default: /usr]
-
 Report bugs to the package provider.
 _ACEOF
 ac_status=$?
@@ -1678,19 +1671,6 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-
-
-
-# Check whether --with-gdal was given.
-if test "${with_gdal+set}" = set; then :
-  withval=$with_gdal;
-else
-  with_gdal=/usr
-fi
-
-
-CGO_CFLAGS="-I$with_gdal/include -L$with_gdal/lib -Wl,-rpath-link=$with_gdal/lib"
 
 
 ac_config_files="$ac_config_files Makefile"

--- a/configure.ac
+++ b/configure.ac
@@ -1,14 +1,4 @@
 dnl A skeletal configure script for GSKY.
 
 AC_INIT(GSKY, 1.0)
-
-AC_ARG_WITH([gdal],
-	    [AS_HELP_STRING([--with-gdal@<:@=DIR@:>@],
-            [location of GDAL library @<:@default: /usr@:>@])],
-            [],
-            [with_gdal=/usr])
-
-CGO_CFLAGS="-I$with_gdal/include -L$with_gdal/lib -Wl,-rpath-link=$with_gdal/lib"
-AC_SUBST(CGO_CFLAGS)
-
 AC_OUTPUT(Makefile)

--- a/crawl/extractor/info.go
+++ b/crawl/extractor/info.go
@@ -5,7 +5,7 @@ package extractor
 // #include "gdal.h"
 // #include "ogr_srs_api.h" /* for SRS calls */
 // #include "cpl_string.h"
-// #cgo LDFLAGS: -lgdal
+// #cgo pkg-config: gdal
 //char *getProj4(char *projWKT)
 //{
 //	char *pszProj4;

--- a/gdal-process/main.go
+++ b/gdal-process/main.go
@@ -2,7 +2,7 @@ package main
 
 // #include "gdal.h"
 // #include "gdal_frmts.h"
-// #cgo LDFLAGS: -lgdal
+// #cgo pkg-config: gdal
 import "C"
 
 import (

--- a/utils/output_encoders.go
+++ b/utils/output_encoders.go
@@ -2,7 +2,7 @@ package utils
 
 // #include "gdal.h"
 // #include "ogr_srs_api.h"
-// #cgo LDFLAGS: -lgdal
+// #cgo pkg-config: gdal
 import "C"
 
 import (

--- a/utils/wps.go
+++ b/utils/wps.go
@@ -3,7 +3,7 @@ package utils
 // #include "gdal.h"
 // #include "ogr_api.h"
 // #include "ogr_srs_api.h"
-// #cgo LDFLAGS: -lgdal
+// #cgo pkg-config: gdal
 import "C"
 
 import (

--- a/worker/gdalprocess/drill.go
+++ b/worker/gdalprocess/drill.go
@@ -6,7 +6,7 @@ package gdalprocess
 // #include "ogr_api.h"
 // #include "ogr_srs_api.h"
 // #include "cpl_string.h"
-// #cgo LDFLAGS: -lgdal
+// #cgo pkg-config: gdal
 // #cgo LDFLAGS: -lnetcdf
 import "C"
 

--- a/worker/gdalprocess/info.go
+++ b/worker/gdalprocess/info.go
@@ -5,7 +5,7 @@ package gdalprocess
 // #include "gdal.h"
 // #include "ogr_srs_api.h" /* for SRS calls */
 // #include "cpl_string.h"
-// #cgo LDFLAGS: -lgdal
+// #cgo pkg-config: gdal
 //char *getProj4(char *projWKT)
 //{
 //	char *pszProj4;

--- a/worker/gdalprocess/warp.go
+++ b/worker/gdalprocess/warp.go
@@ -6,7 +6,7 @@ package gdalprocess
 // #include "ogr_api.h"
 // #include "ogr_srs_api.h"
 // #include "cpl_string.h"
-// #cgo LDFLAGS: -lgdal
+// #cgo pkg-config: gdal
 // int
 // warp_operation(GDALDatasetH hSrcDS, GDALDatasetH hDstDS, int band)
 // {


### PR DESCRIPTION
Use the `#cgo pkg-config` directive in the `.go` files to find compiler and linker flags when building -- no need to pass these on the command line any longer. Have every make target depend on a phony target that runs `pkg-config --exists gdal` to check for the module before running `go`.

Remove `--with-gdal` option from the `configure` script.

@monkeybutter, you may be interested in how this was ultimately done.