### PR TITLE
made grpc recv message size configurable

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -221,7 +221,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 		ctx, ctxCancel := context.WithCancel(ctx)
 		defer ctxCancel()
 		errChan := make(chan error)
-		tp := proc.InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, LoadBalance(conf.ServiceConfig.WorkerNodes), errChan)
+		tp := proc.InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, LoadBalance(conf.ServiceConfig.WorkerNodes), conf.Layers[idx].MaxGrpcRecvMsgSize, errChan)
 		select {
 		case res := <-tp.Process(geoReq):
 			scaleParams := utils.ScaleParams{Offset: geoReq.ScaleParams.Offset,
@@ -402,7 +402,7 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 		ctx, ctxCancel := context.WithCancel(ctx)
 		defer ctxCancel()
 		errChan := make(chan error)
-		tp := proc.InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, LoadBalance(conf.ServiceConfig.WorkerNodes), errChan)
+		tp := proc.InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, LoadBalance(conf.ServiceConfig.WorkerNodes), conf.Layers[idx].MaxGrpcRecvMsgSize, errChan)
 
 		select {
 		case res := <-tp.Process(geoReq):

--- a/processor/tile_internal_pipeline.go
+++ b/processor/tile_internal_pipeline.go
@@ -8,23 +8,25 @@ import (
 )
 
 type TileInternalPipeline struct {
-	Context    context.Context
-	Error      chan error
-	RPCAddress string
-	APIAddress string
+	Context            context.Context
+	Error              chan error
+	RPCAddress         string
+	MaxGrpcRecvMsgSize int
+	APIAddress         string
 }
 
-func NewTileInternalPipeline(ctx context.Context, apiAddr string, rpcAddr string, errChan chan error) *TileInternalPipeline {
+func NewTileInternalPipeline(ctx context.Context, apiAddr string, rpcAddr string, maxGrpcRecvMsgSize int, errChan chan error) *TileInternalPipeline {
 	return &TileInternalPipeline{
-		Context:    ctx,
-		Error:      errChan,
-		RPCAddress: rpcAddr,
-		APIAddress: apiAddr,
+		Context:            ctx,
+		Error:              errChan,
+		RPCAddress:         rpcAddr,
+		MaxGrpcRecvMsgSize: maxGrpcRecvMsgSize,
+		APIAddress:         apiAddr,
 	}
 }
 
 func (dp *TileInternalPipeline) Process(geoReq *GeoTileRequest) chan []utils.Raster {
-	grpcTiler := NewRasterGRPC(dp.Context, dp.RPCAddress, dp.Error)
+	grpcTiler := NewRasterGRPC(dp.Context, dp.RPCAddress, dp.MaxGrpcRecvMsgSize, dp.Error)
 	if grpcTiler == nil {
 		dp.Error <- fmt.Errorf("Couldn't instantiate RPCTiler %s/n", dp.RPCAddress)
 		return nil

--- a/processor/tile_pipeline.go
+++ b/processor/tile_pipeline.go
@@ -7,18 +7,20 @@ import (
 )
 
 type TilePipeline struct {
-	Context    context.Context
-	Error      chan error
-	RPCAddress string
-	MASAddress string
+	Context            context.Context
+	Error              chan error
+	RPCAddress         string
+	MaxGrpcRecvMsgSize int
+	MASAddress         string
 }
 
-func InitTilePipeline(ctx context.Context, masAddr string, rpcAddr string, errChan chan error) *TilePipeline {
+func InitTilePipeline(ctx context.Context, masAddr string, rpcAddr string, maxGrpcRecvMsgSize int, errChan chan error) *TilePipeline {
 	return &TilePipeline{
-		Context:    ctx,
-		Error:      errChan,
-		RPCAddress: rpcAddr,
-		MASAddress: masAddr,
+		Context:            ctx,
+		Error:              errChan,
+		RPCAddress:         rpcAddr,
+		MaxGrpcRecvMsgSize: maxGrpcRecvMsgSize,
+		MASAddress:         masAddr,
 	}
 }
 
@@ -27,7 +29,7 @@ func (dp *TilePipeline) Process(geoReq *GeoTileRequest) chan []utils.Raster {
 	// but we will leave it for now in case we need to handle multile time points for WCS.
 	// In the case of WCS with multiple time points, we will create one request per time point
 	// which will require looping through the input channel as the GeoProcessor currently does.
-	p := NewGeoProcessor(dp.Context, dp.MASAddress, dp.RPCAddress, dp.Error)
+	p := NewGeoProcessor(dp.Context, dp.MASAddress, dp.RPCAddress, dp.MaxGrpcRecvMsgSize, dp.Error)
 
 	p.In <- geoReq
 	close(p.In)

--- a/utils/config.go
+++ b/utils/config.go
@@ -59,24 +59,25 @@ type Layer struct {
 	MetadataURL string `json:"metadata_url"`
 	DataURL     string `json:"data_url"`
 	//CacheLevels  []CacheLevel `json:"cache_levels"`
-	DataSource   string   `json:"data_source"`
-	StartISODate string   `json:"start_isodate"`
-	EndISODate   string   `json:"end_isodate"`
-	StepDays     int      `json:"step_days"`
-	StepHours    int      `json:"step_hours"`
-	StepMinutes  int      `json:"step_minutes"`
-	Accum        bool     `json:"accum"`
-	TimeGen      string   `json:"time_generator"`
-	ResFilter    *int     `json:"resolution_filter"`
-	Dates        []string `json:"dates"`
-	RGBProducts  []string `json:"rgb_products"`
-	Mask         *Mask    `json:"mask"`
-	OffsetValue  float64  `json:"offset_value"`
-	ClipValue    float64  `json:"clip_value"`
-	ScaleValue   float64  `json:"scale_value"`
-	Palette      *Palette `json:"palette"`
-	LegendPath   string   `json:"legend_path"`
-	ZoomLimit    float64  `json:"zoom_limit"`
+	DataSource         string   `json:"data_source"`
+	StartISODate       string   `json:"start_isodate"`
+	EndISODate         string   `json:"end_isodate"`
+	StepDays           int      `json:"step_days"`
+	StepHours          int      `json:"step_hours"`
+	StepMinutes        int      `json:"step_minutes"`
+	Accum              bool     `json:"accum"`
+	TimeGen            string   `json:"time_generator"`
+	ResFilter          *int     `json:"resolution_filter"`
+	Dates              []string `json:"dates"`
+	RGBProducts        []string `json:"rgb_products"`
+	Mask               *Mask    `json:"mask"`
+	OffsetValue        float64  `json:"offset_value"`
+	ClipValue          float64  `json:"clip_value"`
+	ScaleValue         float64  `json:"scale_value"`
+	Palette            *Palette `json:"palette"`
+	LegendPath         string   `json:"legend_path"`
+	ZoomLimit          float64  `json:"zoom_limit"`
+	MaxGrpcRecvMsgSize int      `json:"max_grpc_recv_msg_size"`
 }
 
 // Process contains all the details that a WPS needs
@@ -265,6 +266,8 @@ func LoadAllConfigFiles(rootDir string) (map[string]*Config, error) {
 	return configMap, err
 }
 
+const DefaultRecvMsgSize = 10 * 1024 * 1024
+
 // LoadConfigFile marshalls the config.json document returning an
 // instance of a Config variable containing all the values
 func (config *Config) LoadConfigFile(configFile string) error {
@@ -284,6 +287,10 @@ func (config *Config) LoadConfigFile(configFile string) error {
 		step := time.Minute * time.Duration(60*24*layer.StepDays+60*layer.StepHours+layer.StepMinutes)
 		config.Layers[i].Dates = GenerateDates(layer.TimeGen, start, end, step)
 		config.Layers[i].OWSHostname = config.ServiceConfig.OWSHostname
+
+		if config.Layers[i].MaxGrpcRecvMsgSize <= 0 {
+			config.Layers[i].MaxGrpcRecvMsgSize = DefaultRecvMsgSize
+		}
 
 		if layer.Palette != nil && layer.Palette.Colours != nil && len(layer.Palette.Colours) < 3 {
 			return fmt.Errorf("The colour palette must contain at least 2 colours.")

--- a/utils/config.go
+++ b/utils/config.go
@@ -288,7 +288,7 @@ func (config *Config) LoadConfigFile(configFile string) error {
 		config.Layers[i].Dates = GenerateDates(layer.TimeGen, start, end, step)
 		config.Layers[i].OWSHostname = config.ServiceConfig.OWSHostname
 
-		if config.Layers[i].MaxGrpcRecvMsgSize <= 0 {
+		if config.Layers[i].MaxGrpcRecvMsgSize <= DefaultRecvMsgSize {
 			config.Layers[i].MaxGrpcRecvMsgSize = DefaultRecvMsgSize
 		}
 


### PR DESCRIPTION
@bje- I made grpc recv message size configurable. The default value of gRPC library is 4mb which is too small for analytical operations over a large region such as running WCS over the whole Australia. This fixed https://github.com/nci/gsky/issues/74