### PR TITLE
Start off using Bats with a new integration testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go: 1.9.x
-
+env:
+  - PREFIX=$HOME/local
 services:
   - postgresql
 addons:
@@ -19,6 +20,8 @@ before_script:
   - psql -U postgres -c "create extension postgis"
 
 install:
+  - git clone https://github.com/sstephenson/bats.git
+  - (cd bats && ./install.sh $PREFIX)
   - wget http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz
   - wget http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz.md5
   - md5sum gdal-2.2.4.tar.gz | cmp - gdal-2.2.4.tar.gz.md5

--- a/Makefile.in
+++ b/Makefile.in
@@ -22,6 +22,7 @@ all: concurrent pkg-config
 
 check test: pkg-config
 	go test ./...
+	bats testsuite
 
 concurrent: src/concurrent.c
 	$(CC) -std=c99 -Wall -O2 $< -o $@

--- a/testsuite/api.bats
+++ b/testsuite/api.bats
@@ -1,0 +1,5 @@
+@test "invoking api with -h option prints usage" {
+  run $GOPATH/bin/api -h
+  [ "$status" -eq 2 ]
+  [[ "${lines[0]}" =~ "Usage of " ]]
+}

--- a/testsuite/crawl.bats
+++ b/testsuite/crawl.bats
@@ -1,0 +1,5 @@
+@test "invoking crawl with no options prints an error" {
+  run $GOPATH/bin/crawl
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Please provide a path to a file" ]]
+}

--- a/testsuite/gdal-process.bats
+++ b/testsuite/gdal-process.bats
@@ -1,0 +1,11 @@
+@test "invoking gdal-process with -h prints usage" {
+  run $GOPATH/bin/gdal-process -h
+  [ "$status" -eq 2 ]
+  [[ "${lines[0]}" =~ "Usage of " ]]
+}
+
+@test "invoking gdal-process with invalid flag -x prints an error" {
+  run $GOPATH/bin/gdal-process -x
+  [ "$status" -eq 2 ]
+  [[ "${lines[0]}" = "flag provided but not defined: -x" ]]
+}


### PR DESCRIPTION
Start off using Bats (https://github.com/sstephenson/bats). New tests can now easily be added to the `testsuite/` directory and will ultimately be run by Travis CI. It can be run by hand for now using `make check`.
