### PR TITLE
Travis CI: cache $HOME/local tree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: go
 go: 1.9.x
 env:
-  - PREFIX=$HOME/local
+  - PREFIX=$HOME/local GDALVER=2.2.4
 services:
   - postgresql
+cache:
+  directories:
+    - $PREFIX
 addons:
   postgresql: "9.6"
   apt:
@@ -21,12 +24,14 @@ before_script:
 
 install:
   - git clone https://github.com/sstephenson/bats.git
-  - (cd bats && ./install.sh $PREFIX)
-  - wget http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz
-  - wget http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz.md5
-  - md5sum gdal-2.2.4.tar.gz | cmp - gdal-2.2.4.tar.gz.md5
-  - tar xfvz gdal-2.2.4.tar.gz
-  - (cd gdal-2.2.4 && ./configure --with-openjpeg --prefix=$HOME/gdal-install && make -s all install)
+  - (cd bats && git checkout 03608115df2071fff4eaaff1605768c275e5f81f && ./install.sh $PREFIX)
+  - >
+    if ! test -f $PREFIX/local/lib/libgdal.a ; then
+      wget --quiet http://download.osgeo.org/gdal/$GDALVER/gdal-$GDALVER.tar.gz{,.md5} || exit 1
+      md5sum gdal-$GDALVER.tar.gz | cmp - gdal-$GDALVER.tar.gz.md5 || exit 1
+      tar xfvz gdal-$GDALVER.tar.gz
+      (cd gdal-$GDALVER && ./configure --with-openjpeg --prefix=$HOME/gdal-install && make -s all install)
+    fi
 
 script:
   - cd $TRAVIS_BUILD_DIR/mas/db && psql -f schema.sql -U postgres


### PR DESCRIPTION
This patch enables Travis CI `cache` support and caches `$HOME/local`, where we install all of the prerequisites built from source. In the `install` stage, we now check for one magic file, `$HOME/local/lib/libgdal.a`. The prerequisites are only built if this file is not present.  The build is **significantly** faster!