### PR TITLE
Update package imports to use local forks of small Go packages

### DIFF
--- a/mas/api/api.go
+++ b/mas/api/api.go
@@ -13,7 +13,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/nci/gomemcache/memcache"
 	_ "github.com/lib/pq"
 )
 

--- a/ows.go
+++ b/ows.go
@@ -33,7 +33,7 @@ import (
 
 	_ "net/http/pprof"
 
-	geo "bitbucket.org/monkeyforecaster/geometry"
+	geo "github.com/nci/geometry"
 )
 
 // Global variable to hold the values specified

--- a/processor/drill_indexer.go
+++ b/processor/drill_indexer.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	geo "bitbucket.org/monkeyforecaster/geometry"
+	geo "github.com/nci/geometry"
 )
 
 // string used to format Go ISO times

--- a/utils/wps.go
+++ b/utils/wps.go
@@ -15,7 +15,7 @@ import (
 	"regexp"
 	"strings"
 
-	geo "bitbucket.org/monkeyforecaster/geometry"
+	geo "github.com/nci/geometry"
 )
 
 type Data struct {

--- a/worker/gdalprocess/drill.go
+++ b/worker/gdalprocess/drill.go
@@ -19,7 +19,7 @@ import (
 
 	"encoding/json"
 
-	geo "bitbucket.org/monkeyforecaster/geometry"
+	geo "github.com/nci/geometry"
 	pb "github.com/nci/gsky/worker/gdalservice"
 )
 


### PR DESCRIPTION
Now that we have local forms of some small Go packages (`gomemcache`, `geometry`, `go.promeminfo`), update the package imports to use them. Fixes #88.