### PR TITLE
disabled xml auxiliary file creation in crawler

### DIFF
--- a/crawl/extractor/info.go
+++ b/crawl/extractor/info.go
@@ -36,7 +36,14 @@ import (
 )
 
 func init() {
+	// By default, gdalinfo automatically saves an auxiliary xml file under the
+	// same folder of the data file. This is problematic for us as the data files
+	// we want to crawl are often owned by someone else.
+	// For example, we get this warning for crawling geoglam data: Warning 1:
+	// "Unable to save auxiliary information in /g/data2/u39/public/prep/modis-fc/
+	//   v310/tiles/8-day/cover/FC.v310.MCD43A4.h29v12.2017.006.nc.aux.xml"
 	C.CPLSetConfigOption(C.CString("GDAL_PAM_ENABLED"), C.CString("NO"))
+
 	C.GDALAllRegister()
 }
 

--- a/crawl/extractor/info.go
+++ b/crawl/extractor/info.go
@@ -38,7 +38,7 @@ import (
 func init() {
 	// By default, gdalinfo automatically saves an auxiliary xml file under the
 	// same folder of the data file. This is problematic for us as the data files
-	// we want to crawl are often owned by someone else.
+	// are owned by someone else.
 	// For example, we get this warning for crawling geoglam data: Warning 1:
 	// "Unable to save auxiliary information in /g/data2/u39/public/prep/modis-fc/
 	//   v310/tiles/8-day/cover/FC.v310.MCD43A4.h29v12.2017.006.nc.aux.xml"

--- a/crawl/extractor/info.go
+++ b/crawl/extractor/info.go
@@ -36,6 +36,7 @@ import (
 )
 
 func init() {
+	C.CPLSetConfigOption(C.CString("GDAL_PAM_ENABLED"), C.CString("NO"))
 	C.GDALAllRegister()
 }
 

--- a/crawl/extractor/info.go
+++ b/crawl/extractor/info.go
@@ -38,10 +38,7 @@ import (
 func init() {
 	// By default, gdalinfo automatically saves an auxiliary xml file under the
 	// same folder of the data file. This is problematic for us as the data files
-	// are owned by someone else.
-	// For example, we get this warning for crawling geoglam data: Warning 1:
-	// "Unable to save auxiliary information in /g/data2/u39/public/prep/modis-fc/
-	//   v310/tiles/8-day/cover/FC.v310.MCD43A4.h29v12.2017.006.nc.aux.xml"
+	// we want to crawl are often owned by someone else.
 	C.CPLSetConfigOption(C.CString("GDAL_PAM_ENABLED"), C.CString("NO"))
 
 	C.GDALAllRegister()


### PR DESCRIPTION
@bje- By default, gdalinfo automatically saves an auxiliary xml file under the same folder of the data file. This is problematic for us as the data files are owned by someone else. For example, I got this warning for crawling geoglam data: Warning 1: Unable to save auxiliary information in /g/data2/u39/public/prep/modis-fc/v310/tiles/8-day/cover/FC.v310.MCD43A4.h29v12.2017.006.nc.aux.xml. This PR fixes this.