### PR TITLE
added support for compressing wcs outputs

### DIFF
--- a/utils/output_encoders.go
+++ b/utils/output_encoders.go
@@ -217,7 +217,6 @@ func EncodeGdal(format string, rs []Raster, geot []float64, epsg int) ([]byte, e
 		return []byte{}, fmt.Errorf("Unsupported encoding format: %v", format)
 	}
 
-	// NULL pointer is used to terminate the point array by gdal
 	driverOptions = append(driverOptions, nil)
 
 	w, h, rType, err := ValidateRasterSlice(rs)

--- a/utils/output_encoders.go
+++ b/utils/output_encoders.go
@@ -204,14 +204,21 @@ var GDALTypes = map[string]C.GDALDataType{"Unkown": 0, "Byte": 1, "UInt16": 2, "
 
 func EncodeGdal(format string, rs []Raster, geot []float64, epsg int) ([]byte, error) {
 	var driverName string
+	var driverOptions []*C.char
 	switch strings.ToLower(format) {
 	case "geotiff":
 		driverName = "GTiff"
+		driverOptions = append(driverOptions, C.CString("COMPRESS=LZW"))
 	case "netcdf":
 		driverName = "netCDF"
+		driverOptions = append(driverOptions, C.CString("COMPRESS=DEFLATE"))
+		driverOptions = append(driverOptions, C.CString("ZLEVEL=6"))
 	default:
 		return []byte{}, fmt.Errorf("Unsupported encoding format: %v", format)
 	}
+
+	// NULL pointer is used to terminate the point array by gdal
+	driverOptions = append(driverOptions, nil)
 
 	w, h, rType, err := ValidateRasterSlice(rs)
 	if err != nil {
@@ -231,7 +238,7 @@ func EncodeGdal(format string, rs []Raster, geot []float64, epsg int) ([]byte, e
 	var driverNameC = C.CString(driverName)
 	hDriver := C.GDALGetDriverByName(driverNameC)
 
-	hDstDS := C.GDALCreate(hDriver, C.CString(tempFile), C.int(w), C.int(h), C.int(len(rs)), GDALTypes[rType], nil)
+	hDstDS := C.GDALCreate(hDriver, C.CString(tempFile), C.int(w), C.int(h), C.int(len(rs)), GDALTypes[rType], &driverOptions[0])
 	if hDstDS == nil {
 		return []byte{}, fmt.Errorf("Error creating raster")
 	}


### PR DESCRIPTION
@bje- I added support for compressing wcs outputs. This fixes https://github.com/nci/gsky/issues/90. A few benchmarks using the following wcs request:
`
 http://<gsky server>/ows/geoglam?SERVICE=WCS&service=WCS&crs=EPSG:4326&format=GeoTIFF&request=GetCoverage&height=<height>&width=<width>&version=1.0.0&bbox=-179,-80,180,80&coverage=global:c6:monthly_frac_cover&time=2018-03-01T00:00:00.000Z
`

```
height x width     with compression     no compression (baseline)
500x1000           262kb                       1.4MB
4000x4000          7.6MB                       46MB
8000x8000          65MB                        183MB
```
The compression ratio is good. Plus I also observed virtually no loss of speed.