### PR TITLE
Run 'gofmt -d' without capturing the output for manual inspection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,6 @@ install:
 script:
   - cd $TRAVIS_BUILD_DIR/mas/db && psql -f schema.sql -U postgres
   - go tool vet $TRAVIS_BUILD_DIR
+  - gofmt -d $TRAVIS_BUILD_DIR
   # Ensure that gofmt -d produces zero diff output
   - test -z "$(gofmt -d $TRAVIS_BUILD_DIR)"


### PR DESCRIPTION
This change allows users to easily see in the Travis CI logs why the subsequent test for zero `gofmt` output may have failed.