### PR TITLE
Fix regexps in test cases

### DIFF
--- a/testsuite/api.bats
+++ b/testsuite/api.bats
@@ -1,5 +1,5 @@
 @test "invoking api with -h option prints usage" {
     run $GOPATH/bin/api -h
     [ "$status" -eq 2 ]
-    [[ "${lines[0]}" =~ "Usage of " ]]
+    [[ "${lines[0]}" =~ Usage\ of\  ]]
 }

--- a/testsuite/crawl.bats
+++ b/testsuite/crawl.bats
@@ -1,5 +1,5 @@
 @test "invoking crawl with no options prints an error" {
     run $GOPATH/bin/crawl
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Please provide a path to a file" ]]
+    [[ "$output" =~ Please\ provide\ a\ path\ to\ a\ file ]]
 }


### PR DESCRIPTION
 Bash regexps should not be quoted. These changes remove the quotes and the escape any spaces.