### PR TITLE
Log an error if ListenAndServe fails

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -649,5 +649,5 @@ func main() {
 	http.Handle("/", fs)
 	http.HandleFunc("/ows/", owsHandler)
 	Info.Printf("GSKY is ready")
-	http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", *port), nil)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", *port), nil))
 }


### PR DESCRIPTION
Log an error if `ListenAndServe()` fails (eg due to the address already being in use). Fixes #106.