### PR TITLE
Add a test that runs wgets and looks for expected output

### DIFF
--- a/testsuite/wget.bats
+++ b/testsuite/wget.bats
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function create_config_file() {
+    cat >$1 <<EOF
+	{ "service_config": {
+	    "ows_hostname": "gsky.example.com",
+	    "mas_address": "MAS_IP:80",
+	    "worker_nodes": ["127.0.0.1:6000"]
+          }
+	}
+EOF
+}
+
+function setup() {
+    create_config_file config.json
+    WGET="wget --quiet -O- http://localhost:8080"
+    $GOPATH/bin/gsky &
+    pid=$!
+    disown -r
+    sleep 2  # give the server time to start
+}
+
+function teardown() {
+    kill $pid
+    rm config.json
+}
+
+@test "basic capabilities test" {
+    run $WGET
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ a\ distributed\ geospatial\ data\ server ]]
+}


### PR DESCRIPTION
This PR adds a test case that starts `gsky` on the local system and fires `wget` requests at it, looking for expected output. The first `@test` will make it clear how it works using bash regular expressions. Please consider using this for regression testing and for testing new features, as much as possible.