### PR TITLE
fixed ows trailing slash issue

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -647,6 +647,7 @@ func main() {
 
 	fs := http.FileServer(http.Dir("static"))
 	http.Handle("/", fs)
+	http.HandleFunc("/ows", owsHandler)
 	http.HandleFunc("/ows/", owsHandler)
 	Info.Printf("GSKY is ready")
 	log.Fatal(http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", *port), nil))

--- a/testsuite/wget.bats
+++ b/testsuite/wget.bats
@@ -32,6 +32,6 @@ function teardown() {
 }
 
 @test "ows trailing slash test" {
-    run curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/ows
-    [ "$output" != "301" ]
+    run wget -O /dev/null --max-redirect 0 http://localhost:8080/ows
+    [ "$status" -eq 0 ]
 }

--- a/testsuite/wget.bats
+++ b/testsuite/wget.bats
@@ -30,3 +30,8 @@ function teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ a\ distributed\ geospatial\ data\ server ]]
 }
+
+@test "ows trailing slash test" {
+    run curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/ows
+    [ "$output" != "301" ]
+}


### PR DESCRIPTION
This fixes https://github.com/nci/gsky/issues/130. 
@bje- Can you also please delete this branch: https://github.com/nci/gsky/tree/ows_trailing_slash ? I created it by mistake. I was supposed to create this bug fix branch under my own repo.