### PR TITLE
fixed mas api sql syntax error

### DIFF
--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -361,12 +361,12 @@ create or replace function mas_intersects(
     end if;
 
     if identity_tol is null then
-      identity_tol := -1.0
-    end if
+      identity_tol := -1.0;
+    end if;
 
     if dp_tol is null then
-      dp_tol := -1.0
-    end if
+      dp_tol := -1.0;
+    end if;
 
     -- supplied WKT in wgs84
     if ST_NPoints(in_geom) > 100 and identity_tol >= 0 and dp_tol >= 0 then

--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -356,7 +356,7 @@ create or replace function mas_intersects(
     end if;
 
     in_geom := ST_GeomFromText(wkt, srid);
-    if is_geom is null then
+    if in_geom is null then
       raise exception 'invalid wkt from user inputs';
     end if;
 


### PR DESCRIPTION
@bje- There was syntax error in mas/api/mas.sql due to my careless-ness. This PR fixes it.