### PR TITLE
Fix build codebase inconsistencies

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -43,8 +43,8 @@ install:
 	install $(GOBIN)/grpc-server $(sbindir)/gsky-rpc
 	install $(GOBIN)/crawl $(sbindir)/gsky-crawl
 	install $(GOBIN)/api $(sbindir)/masapi
-	install -m 644 $(srcdir)/zoom.png $(sysconfdir)
-	install -m 644 $(srcdir)/data_unavailable.png $(sysconfdir)
+	install -m 644 $(srcdir)/zoom.png $(datarootdir)
+	install -m 644 $(srcdir)/data_unavailable.png $(datarootdir)
 	for f in $(srcdir)/templates/* ; do install -m 644 $$f $(datarootdir)/gsky/templates ; done
 	cp -rp $(srcdir)/static/* $(datarootdir)/gsky/static
 	for f in $(srcdir)/mas/db/*.sql ; do install -m 644 $$f $(datarootdir)/mas ; done

--- a/ows.go
+++ b/ows.go
@@ -183,7 +183,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 
 		xRes := (params.BBox[2] - params.BBox[0]) / float64(*params.Width)
 		if conf.Layers[idx].ZoomLimit != 0.0 && xRes > conf.Layers[idx].ZoomLimit {
-			out, err := utils.GetEmptyTile(utils.EtcDir+"/zoom.png", *params.Height, *params.Width)
+			out, err := utils.GetEmptyTile(utils.DataDir+"/zoom.png", *params.Height, *params.Width)
 			if err != nil {
 				Info.Printf("Error in the utils.GetEmptyTile(zoom.png): %v\n", err)
 				http.Error(w, err.Error(), 500)
@@ -233,7 +233,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			}
 
 			if norm[0].Width == 0 || norm[0].Height == 0 {
-				out, err := utils.GetEmptyTile(utils.EtcDir+"/data_unavailable.png", *params.Height, *params.Width)
+				out, err := utils.GetEmptyTile(utils.DataDir+"/data_unavailable.png", *params.Height, *params.Width)
 				if err != nil {
 					Info.Printf("Error in the utils.GetEmptyTile(data_unavailable.png): %v\n", err)
 					http.Error(w, err.Error(), 500)

--- a/ows.go
+++ b/ows.go
@@ -59,6 +59,7 @@ func init() {
 	Info = log.New(os.Stdout, "OWS: ", log.Ldate|log.Ltime|log.Lshortfile)
 
 	filePaths := []string{
+		utils.DataDir + "/static/index.html",
 		utils.DataDir + "/templates/WMS_GetCapabilities.tpl",
 		utils.DataDir + "/templates/WMS_DescribeLayer.tpl",
 		utils.DataDir + "/templates/WMS_ServiceException.tpl",
@@ -182,7 +183,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 
 		xRes := (params.BBox[2] - params.BBox[0]) / float64(*params.Width)
 		if conf.Layers[idx].ZoomLimit != 0.0 && xRes > conf.Layers[idx].ZoomLimit {
-			out, err := utils.GetEmptyTile("zoom.png", *params.Height, *params.Width)
+			out, err := utils.GetEmptyTile(utils.EtcDir+"/zoom.png", *params.Height, *params.Width)
 			if err != nil {
 				Info.Printf("Error in the utils.GetEmptyTile(zoom.png): %v\n", err)
 				http.Error(w, err.Error(), 500)
@@ -232,7 +233,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			}
 
 			if norm[0].Width == 0 || norm[0].Height == 0 {
-				out, err := utils.GetEmptyTile("data_unavailable.png", *params.Height, *params.Width)
+				out, err := utils.GetEmptyTile(utils.EtcDir+"/data_unavailable.png", *params.Height, *params.Width)
 				if err != nil {
 					Info.Printf("Error in the utils.GetEmptyTile(data_unavailable.png): %v\n", err)
 					http.Error(w, err.Error(), 500)
@@ -645,7 +646,7 @@ func owsHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 
-	fs := http.FileServer(http.Dir("static"))
+	fs := http.FileServer(http.Dir(utils.DataDir + "/static"))
 	http.Handle("/", fs)
 	http.HandleFunc("/ows", owsHandler)
 	http.HandleFunc("/ows/", owsHandler)

--- a/processor/tile_jpg_enc.go
+++ b/processor/tile_jpg_enc.go
@@ -2,14 +2,14 @@ package processor
 
 import (
 	"bytes"
+	"fmt"
 	"image"
 	"image/color"
 	"image/jpeg"
 	"io"
 	"os"
-	//"time"
-	"fmt"
 	"time"
+	"utils"
 )
 
 type JPGEncoder struct {
@@ -45,7 +45,7 @@ func (enc *JPGEncoder) Run() {
 	case 1:
 		buf := new(bytes.Buffer)
 		if nameSpaces[0] == "OutOfZoom" {
-			f, _ := os.Open("zoom.png")
+			f, _ := os.Open(utils.EtcDir + "/zoom.png")
 			io.Copy(buf, f)
 			enc.Out <- buf.Bytes()
 		}

--- a/processor/tile_jpg_enc.go
+++ b/processor/tile_jpg_enc.go
@@ -46,7 +46,7 @@ func (enc *JPGEncoder) Run() {
 	case 1:
 		buf := new(bytes.Buffer)
 		if nameSpaces[0] == "OutOfZoom" {
-			f, _ := os.Open(utils.EtcDir + "/zoom.png")
+			f, _ := os.Open(utils.DataDir + "/zoom.png")
 			io.Copy(buf, f)
 			enc.Out <- buf.Bytes()
 		}

--- a/processor/tile_jpg_enc.go
+++ b/processor/tile_jpg_enc.go
@@ -9,7 +9,8 @@ import (
 	"io"
 	"os"
 	"time"
-	"utils"
+
+	"github.com/nci/gsky/utils"
 )
 
 type JPGEncoder struct {

--- a/processor/tile_png_enc.go
+++ b/processor/tile_png_enc.go
@@ -10,7 +10,8 @@ import (
 	"io"
 	"log"
 	"os"
-	"utils"
+
+	"github.com/nci/gsky/utils"
 )
 
 type PNGEncoder struct {

--- a/processor/tile_png_enc.go
+++ b/processor/tile_png_enc.go
@@ -2,15 +2,15 @@ package processor
 
 import (
 	"bytes"
+	"fmt"
 	"image"
 	"image/color"
+	"image/draw"
 	"image/png"
 	"io"
-	"os"
-	//"time"
-	"fmt"
-	"image/draw"
 	"log"
+	"os"
+	"utils"
 )
 
 type PNGEncoder struct {
@@ -62,7 +62,7 @@ func (enc *PNGEncoder) Run() {
 	case 1:
 		buf := new(bytes.Buffer)
 		if nameSpaces[0] == "OutOfZoom" {
-			f, err := os.Open("zoom.png")
+			f, err := os.Open(utils.EtcDir + "zoom.png")
 			if err != nil {
 				enc.Error <- fmt.Errorf("missing zoom.png")
 				enc.Out <- nil
@@ -134,7 +134,7 @@ func (enc *PNGEncoder) Run() {
 	default:
 		log.Printf("Cannot encode other than 1 or 3 namespaces into a PNG. Received %d namespaces: %v\n", len(nameSpaces), nameSpaces)
 		buf := new(bytes.Buffer)
-		f, err := os.Open("data_unavailable.png")
+		f, err := os.Open(utils.EtcDir + "/data_unavailable.png")
 		if err != nil {
 			enc.Error <- fmt.Errorf("missing data_unavailable.png")
 			enc.Out <- nil

--- a/processor/tile_png_enc.go
+++ b/processor/tile_png_enc.go
@@ -63,7 +63,7 @@ func (enc *PNGEncoder) Run() {
 	case 1:
 		buf := new(bytes.Buffer)
 		if nameSpaces[0] == "OutOfZoom" {
-			f, err := os.Open(utils.EtcDir + "zoom.png")
+			f, err := os.Open(utils.DataDir + "/zoom.png")
 			if err != nil {
 				enc.Error <- fmt.Errorf("missing zoom.png")
 				enc.Out <- nil
@@ -135,7 +135,7 @@ func (enc *PNGEncoder) Run() {
 	default:
 		log.Printf("Cannot encode other than 1 or 3 namespaces into a PNG. Received %d namespaces: %v\n", len(nameSpaces), nameSpaces)
 		buf := new(bytes.Buffer)
-		f, err := os.Open(utils.EtcDir + "/data_unavailable.png")
+		f, err := os.Open(utils.DataDir + "/data_unavailable.png")
 		if err != nil {
 			enc.Error <- fmt.Errorf("missing data_unavailable.png")
 			enc.Out <- nil


### PR DESCRIPTION
@bje- Today when I was trying to build a docker image for gsky using ./configure and make instead of the ansible scripts we internally used, I found there are a few places in the codebase that are not consistent with the Makefile script. This PR fixes them.