### PR TITLE
install png files into dataroot/gsky

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -43,8 +43,8 @@ install:
 	install $(GOBIN)/grpc-server $(sbindir)/gsky-rpc
 	install $(GOBIN)/crawl $(sbindir)/gsky-crawl
 	install $(GOBIN)/api $(sbindir)/masapi
-	install -m 644 $(srcdir)/zoom.png $(datarootdir)
-	install -m 644 $(srcdir)/data_unavailable.png $(datarootdir)
+	install -m 644 $(srcdir)/zoom.png $(datarootdir)/gsky
+	install -m 644 $(srcdir)/data_unavailable.png $(datarootdir)/gsky
 	cp -rp $(srcdir)/templates/* $(datarootdir)/gsky/templates
 	cp -rp $(srcdir)/static/* $(datarootdir)/gsky/static
 	for f in $(srcdir)/mas/db/*.sql $(srcdir)/mas/api/*.sql ; do install -m 644 $$f $(datarootdir)/mas ; done


### PR DESCRIPTION
@bje- the png files need to be under `$dataroot/gsky` like `templates/` and `static/`. Chris needs this fix urgently. So i'll go ahead to merge this PR.