### PR TITLE
 install png files to datarootdir/gsky

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -42,8 +42,8 @@ install:
 	install $(GOBIN)/grpc-server $(sbindir)/gsky-rpc
 	install $(GOBIN)/crawl $(sbindir)/gsky-crawl
 	install $(GOBIN)/api $(sbindir)/masapi
-	install -m 644 $(srcdir)/zoom.png $(datarootdir)
-	install -m 644 $(srcdir)/data_unavailable.png $(datarootdir)
+	install -m 644 $(srcdir)/zoom.png $(datarootdir)/gsky
+	install -m 644 $(srcdir)/data_unavailable.png $(datarootdir)/gsky
 	for f in $(srcdir)/templates/* ; do install -m 644 $$f $(datarootdir)/gsky/templates ; done
 	cp -rp $(srcdir)/static/* $(datarootdir)/gsky/static
 	for f in $(srcdir)/mas/db/*.sql $(srcdir)/mas/api/*.sql ; do install -m 644 $$f $(datarootdir)/mas ; done


### PR DESCRIPTION
@bje- The png files need to be installed to `$(datarootdir)/gsky` like `templates/` and `static/`. Chris needs this urgently. So I'll go ahead to merge this PR.