### PR TITLE
added check against some zero timestamp steps to prevent infinite loop

### DIFF
--- a/utils/api_test.go
+++ b/utils/api_test.go
@@ -218,3 +218,38 @@ text with tab	te	xt
 	}
 
 }
+
+func TestGenerateDatesMCD43A4(t *testing.T) {
+	const ISOFormat = "2006-01-02T15:04:05.000Z"
+
+	start, _ := time.Parse(ISOFormat, "2001-01-02T00:00:00.000Z")
+	end, _ := time.Parse(ISOFormat, "2002-01-02T00:00:00.000Z")
+	step, _ := time.ParseDuration("0s")
+	timestamps := GenerateDatesMCD43A4(start, end, step)
+	if len(timestamps) > 0 {
+		t.Errorf("Failed to handle zero time step")
+		return
+	}
+
+	step, _ = time.ParseDuration("72h")
+	timestamps = GenerateDatesMCD43A4(start, end, step)
+	if len(timestamps) == 0 {
+		t.Errorf("Failed to handle non-zero time step, %v, %v, %v", start, end, step)
+		return
+	}
+}
+
+func TestGenerateDates(t *testing.T) {
+	const ISOFormat = "2006-01-02T15:04:05.000Z"
+
+	start, _ := time.Parse(ISOFormat, "2001-01-02T00:00:00.000Z")
+	end, _ := time.Parse(ISOFormat, "2002-01-02T00:00:00.000Z")
+	step, _ := time.ParseDuration("0s")
+
+	timestamps := GenerateDates("not_found", start, end, step)
+	if len(timestamps) > 0 {
+		t.Errorf("Non-existing timestamp generator successfully generates timestamps")
+		return
+	}
+
+}

--- a/utils/config.go
+++ b/utils/config.go
@@ -166,6 +166,9 @@ func GenerateDatesAux(start, end time.Time, stepMins time.Duration) []string {
 // dates from its especification in the Config.Layer struct.
 func GenerateDatesMCD43A4(start, end time.Time, stepMins time.Duration) []string {
 	dates := []string{}
+	if int64(stepMins) <= 0 {
+		return dates
+	}
 	year := start.Year()
 	for start.Before(end) {
 		for start.Year() == year && start.Before(end) {
@@ -183,6 +186,9 @@ func GenerateDatesMCD43A4(start, end time.Time, stepMins time.Duration) []string
 
 func GenerateDatesGeoglam(start, end time.Time, stepMins time.Duration) []string {
 	dates := []string{}
+	if int64(stepMins) <= 0 {
+		return dates
+	}
 	year := start.Year()
 	for start.Before(end) {
 		for start.Year() == year && start.Before(end) {
@@ -235,6 +241,9 @@ func GenerateYearlyDates(start, end time.Time, stepMins time.Duration) []string 
 
 func GenerateDatesRegular(start, end time.Time, stepMins time.Duration) []string {
 	dates := []string{}
+	if int64(stepMins) <= 0 {
+		return dates
+	}
 	for start.Before(end) {
 		dates = append(dates, start.Format(ISOFormat))
 		start = start.Add(stepMins)
@@ -481,11 +490,7 @@ func (config *Config) GetLayerDates(iLayer int) {
 			}
 		}
 
-		if int64(step) > 0 {
-			config.Layers[iLayer].Dates = GenerateDates(layer.TimeGen, start, end, step)
-		} else {
-			log.Printf("Invalid time steps: %v", step)
-		}
+		config.Layers[iLayer].Dates = GenerateDates(layer.TimeGen, start, end, step)
 	}
 
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -380,6 +380,10 @@ func GenerateDates(name string, start, end time.Time, stepMins time.Duration) []
 	dateGen["monthly"] = GenerateMonthlyDates
 	dateGen["yearly"] = GenerateYearlyDates
 
+	if _, ok := dateGen[name]; !ok {
+		return []string{}
+	}
+
 	return dateGen[name](start, end, stepMins)
 }
 


### PR DESCRIPTION
@bje- I added check against some zero timestamp steps. If we don't have these checks, zero steps will cause infinite loop. Also, some timestamp steps can be zero as they're not used.