### PR TITLE
added no-cache for getCaps

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -128,6 +128,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			conf.GetLayerDates(iLayer)
 		}
 
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 		err := utils.ExecuteWriteTemplateFile(w, conf,
 			utils.DataDir+"/templates/WMS_GetCapabilities.tpl")
 		if err != nil {
@@ -330,6 +331,7 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 			newConf.Layers[i].Dates = []string{newConf.Layers[i].Dates[0], newConf.Layers[i].Dates[len(newConf.Layers[i].Dates)-1]}
 		}
 
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 		err := utils.ExecuteWriteTemplateFile(w, &newConf, utils.DataDir+"/templates/WCS_GetCapabilities.tpl")
 		if err != nil {
 			http.Error(w, err.Error(), 500)


### PR DESCRIPTION
@bje- It's quite often that the clients (e.g. terriajs) has a proxy server like varnish in front of gsky endpoint. The problem is that once we updated the timestamps in GetCaps, the proxy server still caches the old reponse for at least 24 hours. We will need to instruct the proxy server not to cache GetCaps response.