### PR TITLE
added support for parsing sentinel2 namespaces

### DIFF
--- a/crawl/extractor/ruleset.go
+++ b/crawl/extractor/ruleset.go
@@ -139,11 +139,18 @@ var CollectionRuleSets = []RuleSet{
 		`SRTM_(?P<product>[A-Z]+)_(?P<x_coord>-?\d+)_(?P<y_coord>-?\d+)_(?P<year>\d\d\d\d)(?P<month>\d\d)(?P<day>\d\d)(?P<hour>\d\d)(?P<minute>\d\d)(?P<second>\d\d)`,
 	},
 	RuleSet{
-		"sentinel2_ard",
-		NSDataset,
+		"sentinel2_ard_nbar_nbart",
+		NSPath,
 		SRSDetect,
 		Proj4Detect,
-		`_(?P<year>\d\d\d\d)(?P<month>\d\d)(?P<day>\d\d)T(?P<hour>\d\d)(?P<minute>\d\d)(?P<second>\d\d)_`,
+		`_(?P<year>\d\d\d\d)(?P<month>\d\d)(?P<day>\d\d)T(?P<hour>\d\d)(?P<minute>\d\d)(?P<second>\d\d)_(?P<namespace>[\w\d_]+)\.TIF`,
+	},
+	RuleSet{
+		"sentinel2_ard_qa_supp",
+		NSPath,
+		SRSDetect,
+		Proj4Detect,
+		`_(?P<year>\d\d\d\d)(?P<month>\d\d)(?P<day>\d\d)T(?P<hour>\d\d)(?P<minute>\d\d)(?P<second>\d\d)_.+06_(?P<namespace>[\w\d_]+)\.TIF`,
 	},
 	RuleSet{
 		"default",


### PR DESCRIPTION
@bje- It turns out that the namespaces in the sentinel2 datasets are not stored in the data files. So we have to parse the filenames to extract those using RegEx.