### PR TITLE
fixed auto mas timestamp issues

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -125,7 +125,9 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 		}
 
 		for iLayer := range conf.Layers {
-			conf.GetLayerDates(iLayer)
+			if conf.Layers[iLayer].AutoRefreshTimestamps {
+				conf.GetLayerDates(iLayer)
+			}
 		}
 
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")

--- a/templates/WCS_DescribeCoverage.tpl
+++ b/templates/WCS_DescribeCoverage.tpl
@@ -11,16 +11,16 @@
     <lonLatEnvelope srsName="urn:ogc:def:crs:OGC:1.3:CRS84">
       <gml:pos>-180.0 -90.0</gml:pos>
       <gml:pos>180.0 90.0</gml:pos>
-      <gml:timePosition>{{ .StartISODate }}</gml:timePosition>
-      <gml:timePosition>{{ .EndISODate }}</gml:timePosition>
+      <gml:timePosition>{{ .EffectiveStartDate }}</gml:timePosition>
+      <gml:timePosition>{{ .EffectiveEndDate }}</gml:timePosition>
     </lonLatEnvelope>
     <domainSet>
       <spatialDomain>
         <gml:EnvelopeWithTimePeriod srsName="urn:ogc:def:crs:OGC:1.3:CRS84">
           <gml:pos dimension="2">-180.0 -90.0</gml:pos>
           <gml:pos dimension="2">180.0 90.0</gml:pos>
-          <gml:timePosition>{{ .StartISODate }}</gml:timePosition>
-          <gml:timePosition>{{ .EndISODate }}</gml:timePosition>
+          <gml:timePosition>{{ .EffectiveStartDate }}</gml:timePosition>
+          <gml:timePosition>{{ .EffectiveEndDate }}</gml:timePosition>
         </gml:EnvelopeWithTimePeriod>
         <gml:RectifiedGrid srsName="EPSG:4326" dimension="2">
           <gml:limits>

--- a/utils/config.go
+++ b/utils/config.go
@@ -70,9 +70,12 @@ type Layer struct {
 	MetadataURL string `json:"metadata_url"`
 	DataURL     string `json:"data_url"`
 	//CacheLevels  []CacheLevel `json:"cache_levels"`
-	DataSource               string   `json:"data_source"`
-	StartISODate             string   `json:"start_isodate"`
-	EndISODate               string   `json:"end_isodate"`
+	DataSource               string `json:"data_source"`
+	StartISODate             string `json:"start_isodate"`
+	EndISODate               string `json:"end_isodate"`
+	EffectiveStartDate       string
+	EffectiveEndDate         string
+	AutoRefreshTimestamps    bool     `json:"auto_refresh_timestamps"`
 	StepDays                 int      `json:"step_days"`
 	StepHours                int      `json:"step_hours"`
 	StepMinutes              int      `json:"step_minutes"`
@@ -488,11 +491,6 @@ func (config *Config) GetLayerDates(iLayer int) {
 	step := time.Minute * time.Duration(60*24*layer.StepDays+60*layer.StepHours+layer.StepMinutes)
 	if strings.TrimSpace(strings.ToLower(layer.TimeGen)) == "mas" {
 		config.Layers[iLayer].Dates = GenerateDatesMas(layer.StartISODate, layer.EndISODate, config.ServiceConfig.MASAddress, layer.DataSource, layer.RGBProducts, step)
-		nDates := len(config.Layers[iLayer].Dates)
-		if nDates > 0 {
-			config.Layers[iLayer].StartISODate = config.Layers[iLayer].Dates[0]
-			config.Layers[iLayer].EndISODate = config.Layers[iLayer].Dates[nDates-1]
-		}
 	} else {
 		start, errStart := time.Parse(ISOFormat, layer.StartISODate)
 		if errStart != nil {
@@ -512,6 +510,11 @@ func (config *Config) GetLayerDates(iLayer int) {
 		config.Layers[iLayer].Dates = GenerateDates(layer.TimeGen, start, end, step)
 	}
 
+	nDates := len(config.Layers[iLayer].Dates)
+	if nDates > 0 {
+		config.Layers[iLayer].EffectiveStartDate = config.Layers[iLayer].Dates[0]
+		config.Layers[iLayer].EffectiveEndDate = config.Layers[iLayer].Dates[nDates-1]
+	}
 }
 
 // LoadConfigFileTemplate parses the config as a Jet


### PR DESCRIPTION
https://github.com/nci/gsky/pull/204 introduced a regression bug that results in incorrect MAS query returning wrong timestamps. This PR fixes this problem.