### PR TITLE
changed into using GDAL built-in cache flush

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -765,11 +765,7 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 			}
 
 			if (ir+1)%checkpointThreshold == 0 {
-				hDstDS, err = utils.EncodeGdalFlush(hDstDS, masterTempFile, driverFormat)
-				if err != nil {
-					Info.Printf("Error in the pipeline: %v\n", err)
-					http.Error(w, err.Error(), 500)
-				}
+				utils.EncodeGdalFlush(hDstDS)
 				runtime.GC()
 			}
 		}

--- a/utils/output_encoders.go
+++ b/utils/output_encoders.go
@@ -425,27 +425,8 @@ func EncodeGdalMerge(ctx context.Context, hDstDS C.GDALDatasetH, format string, 
 	return nil
 }
 
-func EncodeGdalFlush(hDstDS C.GDALDatasetH, tempFile string, format string) (C.GDALDatasetH, error) {
-	driverName, err := GetDriverNameFromFormat(format)
-	if err != nil {
-		return nil, err
-	}
-
-	C.GDALClose(hDstDS)
-
-	tempFileC := C.CString(tempFile)
-	defer C.free(unsafe.Pointer(tempFileC))
-
-	driverList := []*C.char{C.CString(driverName)}
-	defer C.free(unsafe.Pointer(driverList[0]))
-
-	newhDS := C.GDALOpenEx(tempFileC, C.GDAL_OF_UPDATE, &driverList[0], nil, nil)
-
-	if newhDS == nil {
-		return nil, fmt.Errorf("Failed to reopen existing dataset: %v", tempFile)
-	}
-
-	return newhDS, nil
+func EncodeGdalFlush(hDstDS C.GDALDatasetH) {
+	C.GDALFlushCache(hDstDS)
 }
 
 func EncodeGdalClose(hDstDS C.GDALDatasetH) {


### PR DESCRIPTION
The previous implementation for flushing GDAL cache requires closing the open dataset and then reopening it in update mode. This method guarantees the flush of unwritten data in memory when the dataset is closed. Having said that, not all GDAL drivers support opening dataset in update mode. Thus the aforementioned method is not generic. Instead, we should seek to use the GDAL built-in GDALFlushCache() API for such a purpose. This method falls back safely if the underlying driver does not support flushing. This fixes the "ailed to reopen existing dataset" error in https://github.com/nci/gsky/issues/208