### PR TITLE
Token timestamp cache

### DIFF
--- a/mas/api/api.go
+++ b/mas/api/api.go
@@ -98,12 +98,14 @@ func handler(response http.ResponseWriter, request *http.Request) {
 				nullif($1,'')::text,
 				nullif($2,'')::timestamptz,
 				nullif($3,'')::timestamptz,
-				string_to_array(nullif($4,''), ',')
+				string_to_array(nullif($4,''), ','),
+				nullif($5,'')::text
 			) as json`,
 			request.URL.Path,
 			request.FormValue("time"),
 			request.FormValue("until"),
 			request.FormValue("namespace"),
+			request.FormValue("token"),
 		).Scan(&payload)
 
 	} else {

--- a/mas/db/shard.sql
+++ b/mas/db/shard.sql
@@ -688,7 +688,8 @@ drop table if exists timestamps_cache cascade;
 -- cache for timestamps
 create unlogged table timestamps_cache (
   query_id text primary key,
-  timestamps jsonb not null
+  timestamps jsonb not null,
+  query_token text
 );
 
 create or replace function refresh_caches()

--- a/mas/db/shard_create.sh
+++ b/mas/db/shard_create.sh
@@ -31,7 +31,7 @@ insert into public.shards (sh_code, sh_path)
 
 \\i shard.sql
 
-grant insert,update on ${shard}.timestamps_cache to api;
+grant select,insert,update on ${shard}.timestamps_cache to api;
 
 EOD
 )

--- a/ows.go
+++ b/ows.go
@@ -380,9 +380,7 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 		newConf := *conf
 		newConf.Layers = make([]utils.Layer, len(newConf.Layers))
 		for i, layer := range conf.Layers {
-			if layer.AutoRefreshTimestamps {
-				conf.GetLayerDates(i)
-			}
+			conf.GetLayerDates(i)
 			newConf.Layers[i] = layer
 			newConf.Layers[i].Dates = []string{newConf.Layers[i].Dates[0], newConf.Layers[i].Dates[len(newConf.Layers[i].Dates)-1]}
 		}

--- a/ows.go
+++ b/ows.go
@@ -125,9 +125,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 		}
 
 		for iLayer := range conf.Layers {
-			if conf.Layers[iLayer].AutoRefreshTimestamps {
-				conf.GetLayerDates(iLayer)
-			}
+			conf.GetLayerDates(iLayer)
 		}
 
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")

--- a/utils/config.go
+++ b/utils/config.go
@@ -162,7 +162,7 @@ const ISOFormat = "2006-01-02T15:04:05.000Z"
 
 func GenerateDatesAux(start, end time.Time, stepMins time.Duration) []string {
 	dates := []string{}
-	for start.Before(end) {
+	for !start.After(end) {
 		dates = append(dates, start.Format(ISOFormat))
 		start = time.Date(start.Year()+1, 1, 1, 0, 0, 0, 0, time.UTC)
 	}
@@ -177,12 +177,12 @@ func GenerateDatesMCD43A4(start, end time.Time, stepMins time.Duration) []string
 		return dates
 	}
 	year := start.Year()
-	for start.Before(end) {
-		for start.Year() == year && start.Before(end) {
+	for !start.After(end) {
+		for start.Year() == year && !start.After(end) {
 			dates = append(dates, start.Format(ISOFormat))
 			start = start.Add(stepMins)
 		}
-		if !start.Before(end) {
+		if start.After(end) {
 			break
 		}
 		year = start.Year()
@@ -197,8 +197,8 @@ func GenerateDatesGeoglam(start, end time.Time, stepMins time.Duration) []string
 		return dates
 	}
 	year := start.Year()
-	for start.Before(end) {
-		for start.Year() == year && start.Before(end) {
+	for !start.After(end) {
+		for start.Year() == year && !start.After(end) {
 			dates = append(dates, start.Format(ISOFormat))
 			nextDate := start.AddDate(0, 0, 4)
 			if start.Month() == nextDate.Month() {
@@ -208,7 +208,7 @@ func GenerateDatesGeoglam(start, end time.Time, stepMins time.Duration) []string
 			}
 
 		}
-		if !start.Before(end) {
+		if start.After(end) {
 			break
 		}
 		year = start.Year()
@@ -219,7 +219,7 @@ func GenerateDatesGeoglam(start, end time.Time, stepMins time.Duration) []string
 
 func GenerateDatesChirps20(start, end time.Time, stepMins time.Duration) []string {
 	dates := []string{}
-	for start.Before(end) {
+	for !start.After(end) {
 		dates = append(dates, time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, time.UTC).Format(ISOFormat))
 		dates = append(dates, time.Date(start.Year(), start.Month(), 11, 0, 0, 0, 0, time.UTC).Format(ISOFormat))
 		dates = append(dates, time.Date(start.Year(), start.Month(), 21, 0, 0, 0, 0, time.UTC).Format(ISOFormat))
@@ -230,7 +230,7 @@ func GenerateDatesChirps20(start, end time.Time, stepMins time.Duration) []strin
 
 func GenerateMonthlyDates(start, end time.Time, stepMins time.Duration) []string {
 	dates := []string{}
-	for start.Before(end) {
+	for !start.After(end) {
 		start = start.AddDate(0, 1, 0)
 		dates = append(dates, time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC).Format(ISOFormat))
 	}
@@ -239,7 +239,7 @@ func GenerateMonthlyDates(start, end time.Time, stepMins time.Duration) []string
 
 func GenerateYearlyDates(start, end time.Time, stepMins time.Duration) []string {
 	dates := []string{}
-	for start.Before(end) {
+	for !start.After(end) {
 		start = start.AddDate(1, 0, 0)
 		dates = append(dates, time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC).Format(ISOFormat))
 	}
@@ -251,7 +251,7 @@ func GenerateDatesRegular(start, end time.Time, stepMins time.Duration) []string
 	if int64(stepMins) <= 0 {
 		return dates
 	}
-	for start.Before(end) {
+	for !start.After(end) {
 		dates = append(dates, start.Format(ISOFormat))
 		start = start.Add(stepMins)
 	}
@@ -333,7 +333,7 @@ func GenerateDatesMas(start, end string, masAddress string, collection string, n
 		}
 
 		refDates := []time.Time{}
-		for startDate.Before(endDate) {
+		for !startDate.After(endDate) {
 			refDates = append(refDates, startDate)
 			startDate = startDate.Add(stepMins)
 		}


### PR DESCRIPTION
Added support for a token-based approach to automatically refresh timestamps from MAS. During the GSKY startup, GSKY will pull MAS for timestamps and MAS will also return a token to GSKY. If GSKY presents this token to MAS for subsequent timestamp queries, MAS will return empty timestamps assuming that GSKY caches the timestamps. If GSKY doesn't present the token to MAS, MAS will return the full range of timestamps. In short, this approach enables lazy refresh of MAS timestamps.