### PR TITLE
fixed a corner case for saving MAS token when MAS shard is empty

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -502,6 +502,7 @@ func (config *Config) GetLayerDates(iLayer int) {
 			config.Layers[iLayer].TimestampToken = token
 		} else if len(timestamps) == 0 && len(token) > 0 {
 			log.Printf("Cached %d timestamps", len(config.Layers[iLayer].Dates))
+			config.Layers[iLayer].TimestampToken = token
 			return
 		} else {
 			log.Printf("Failed to get MAS timestamps")
@@ -531,6 +532,7 @@ func (config *Config) GetLayerDates(iLayer int) {
 				return
 			} else if len(masTimestamps) == 0 && len(token) > 0 {
 				log.Printf("Cached %d timestamps", len(config.Layers[iLayer].Dates))
+				config.Layers[iLayer].TimestampToken = token
 				return
 			}
 			config.Layers[iLayer].TimestampToken = token


### PR DESCRIPTION
If the MAS shard has no data and a MAS timestamps query comes in, a token will be generated to reflect the current empty state of the shard. This token will also need to be saved in GSKY config code. 