### PR TITLE
fixed WCS file descriptor leak

### DIFF
--- a/utils/output_encoders.go
+++ b/utils/output_encoders.go
@@ -429,8 +429,10 @@ func EncodeGdalFlush(hDstDS C.GDALDatasetH) {
 	C.GDALFlushCache(hDstDS)
 }
 
-func EncodeGdalClose(hDstDS C.GDALDatasetH) {
-	C.GDALClose(hDstDS)
+func EncodeGdalClose(hDstDS *C.GDALDatasetH) {
+	if hDstDS != nil && *hDstDS != nil {
+		C.GDALClose(*hDstDS)
+	}
 }
 
 // ExtractEPSGCode parses an SRS string and gets


### PR DESCRIPTION
Despite the fact that GSKY deletes the temporal raster files after the completion of WCS request, the disk space allocated to those temporal files are not releases because there are open file descriptors reference these files. These open file descriptors come from calling GDALOpen() to create the temporal files. If WCS returns prematurely due to processing error, these open file descriptors will not be closed which results in GDAL file descriptor leakage. This PR  "defers" GDALClose() to ensure the file descriptors closed whenever WCS returns.