### PR TITLE
crawl Sentinel2 yaml files

### DIFF
--- a/crawl/crawl.go
+++ b/crawl/crawl.go
@@ -27,12 +27,14 @@ func main() {
 
 	concLimit := DefaultConcLimit
 	approx := true
+	sentinel2Yaml := false
 
 	if len(os.Args) > 2 {
 		flagSet := flag.NewFlagSet("Usage", flag.ExitOnError)
 		flagSet.IntVar(&concLimit, "conc", DefaultConcLimit, "Concurrent limit on processing subdatasets")
 		var exact bool
 		flagSet.BoolVar(&exact, "exact", false, "Compute exact statistics")
+		flagSet.BoolVar(&sentinel2Yaml, "sentinel2_yaml", false, "Extract sentinel2 metadata from its yaml files")
 		flagSet.Parse(os.Args[2:])
 
 		approx = !exact
@@ -44,7 +46,13 @@ func main() {
 		path = scanner.Text()
 	}
 
-	geoFile, err := extr.ExtractGDALInfo(path, concLimit, approx)
+	var geoFile *extr.GeoFile
+	var err error
+	if sentinel2Yaml {
+		geoFile, err = extr.ExtractSentinel2Yaml(path)
+	} else {
+		geoFile, err = extr.ExtractGDALInfo(path, concLimit, approx)
+	}
 	ensure(err)
 
 	out, err := json.Marshal(&geoFile)

--- a/crawl/extractor/info_sentinel2_yaml.go
+++ b/crawl/extractor/info_sentinel2_yaml.go
@@ -1,0 +1,194 @@
+package extractor
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"time"
+)
+
+type ArdBand struct {
+	Info struct {
+		Geotransform []float64
+		Height       int
+		Width        int
+	}
+
+	Path string
+}
+
+type ArdMetadata struct {
+	Format struct {
+		Name string
+	}
+
+	Extent struct {
+		Center_dt string
+	}
+
+	Grid_spatial struct {
+		Projection struct {
+			Geo_ref_Points struct {
+				Ll struct {
+					X string
+					Y string
+				}
+				Lr struct {
+					X string
+					Y string
+				}
+				Ul struct {
+					X string
+					Y string
+				}
+				Ur struct {
+					X string
+					Y string
+				}
+			}
+			Spatial_reference string
+		}
+	}
+
+	Image struct {
+		Bands map[string]*ArdBand
+	}
+}
+
+func ExtractSentinel2Yaml(filename string) (*GeoFile, error) {
+	rawData, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	ard := ArdMetadata{}
+
+	err = yaml.Unmarshal(rawData, &ard)
+	if err != nil {
+		return nil, err
+	}
+
+	dsPath, _ := filepath.Split(filename)
+	geoFile := GeoFile{FileName: filename, Driver: ard.Format.Name}
+
+	timestampFormat := "2006-01-02T15:04:05Z"
+	timestamp, err := time.ParseInLocation(timestampFormat, ard.Extent.Center_dt, time.UTC)
+	if err != nil {
+		log.Printf("invalid timestamp: %v", err)
+	}
+
+	for ns, aband := range ard.Image.Bands {
+		ds := &GeoMetaData{
+			DataSetName:  filepath.Join(dsPath, aband.Path),
+			NameSpace:    ns,
+			Type:         getBandDataType(ns),
+			RasterCount:  1,
+			TimeStamps:   []time.Time{timestamp},
+			XSize:        int32(aband.Info.Width),
+			YSize:        int32(aband.Info.Height),
+			GeoTransform: aband.Info.Geotransform,
+			Polygon: fmt.Sprintf("POLYGON ((%s %s,%s %s,%s %s,%s %s,%s %s))",
+				ard.Grid_spatial.Projection.Geo_ref_Points.Ul.X,
+				ard.Grid_spatial.Projection.Geo_ref_Points.Ul.Y,
+				ard.Grid_spatial.Projection.Geo_ref_Points.Ll.X,
+				ard.Grid_spatial.Projection.Geo_ref_Points.Ll.Y,
+				ard.Grid_spatial.Projection.Geo_ref_Points.Lr.X,
+				ard.Grid_spatial.Projection.Geo_ref_Points.Lr.Y,
+				ard.Grid_spatial.Projection.Geo_ref_Points.Ur.X,
+				ard.Grid_spatial.Projection.Geo_ref_Points.Ur.Y,
+				ard.Grid_spatial.Projection.Geo_ref_Points.Ul.X,
+				ard.Grid_spatial.Projection.Geo_ref_Points.Ul.Y),
+
+			ProjWKT: ard.Grid_spatial.Projection.Spatial_reference,
+			Proj4:   "+proj=utm +zone=52 +south +datum=WGS84 +units=m +no_defs ",
+		}
+
+		geoFile.DataSets = append(geoFile.DataSets, ds)
+	}
+
+	return &geoFile, nil
+}
+
+func getBandDataType(bandName string) string {
+	switch bandName {
+	case "nbart_contiguity":
+		return "Byte"
+	case "nbart_red_edge_2":
+		return "Int16"
+	case "nbart_swir_3":
+		return "Int16"
+	case "solar_zenith":
+		return "Float32"
+	case "nbar_contiguity":
+		return "Byte"
+	case "nbar_red":
+		return "Int16"
+	case "nbart_nir_1":
+		return "Int16"
+	case "nbart_red":
+		return "Int16"
+	case "nbart_red_edge_1":
+		return "Int16"
+	case "satellite_azimuth":
+		return "Float32"
+	case "solar_azimuth":
+		return "Float32"
+	case "timedelta":
+		return "Float32"
+	case "nbar_blue":
+		return "Int16"
+	case "nbar_green":
+		return "Int16"
+	case "nbar_nir_1":
+		return "Int16"
+	case "nbar_red_edge_2":
+		return "Int16"
+	case "exiting":
+		return "Float32"
+	case "fmask":
+		return "Byte"
+	case "satellite_view":
+		return "Float32"
+	case "relative_slope":
+		return "Float32"
+	case "nbar_red_edge_1":
+		return "Int16"
+	case "nbar_red_edge_3":
+		return "Int16"
+	case "nbart_nir_2":
+		return "Int16"
+	case "relative_azimuth":
+		return "Float32"
+	case "azimuthal_exiting":
+		return "Float32"
+	case "azimuthal_incident":
+		return "Float32"
+	case "incident":
+		return "Float32"
+	case "nbart_red_edge_3":
+		return "Int16"
+	case "nbar_coastal_aerosol":
+		return "Int16"
+	case "nbar_swir_2":
+		return "Int16"
+	case "terrain_shadow":
+		return "Byte"
+	case "nbart_green":
+		return "Int16"
+	case "nbart_swir_2":
+		return "Int16"
+	case "nbar_nir_2":
+		return "Int16"
+	case "nbar_swir_3":
+		return "Int16"
+	case "nbart_blue":
+		return "Int16"
+	case "nbart_coastal_aerosol":
+		return "Int16"
+	default:
+		log.Printf("unknown data type for band: %v", bandName)
+		return "Byte"
+	}
+}

--- a/crawl/extractor/types.go
+++ b/crawl/extractor/types.go
@@ -21,12 +21,12 @@ type GeoMetaData struct {
 	Polygon      string      `json:"polygon"`
 	ProjWKT      string      `json:"proj_wkt"`
 	Proj4        string      `json:"proj4"`
-	Mins         []float64   `json:"mins"`
-	Maxs         []float64   `json:"maxs"`
-	Means        []float64   `json:"means"`
-	StdDevs      []float64   `json:"stddevs"`
-	SampleCounts []int       `json:"sample_counts"`
-	NoData       float64     `json:"nodata"`
+	Mins         []float64   `json:"mins,omitempty"`
+	Maxs         []float64   `json:"maxs,omitempty"`
+	Means        []float64   `json:"means,omitempty"`
+	StdDevs      []float64   `json:"stddevs,omitempty"`
+	SampleCounts []int       `json:"sample_counts,omitempty"`
+	NoData       float64     `json:"nodata,omitempty"`
 }
 
 type GeoFile struct {


### PR DESCRIPTION
Added support for extracting Sentinel 2 metadata by crawling its yaml files instead of the raw files. We experience several order of magnitude speedup.