### PR TITLE
Added support for WMS styles

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -521,6 +521,7 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 				ZoomLimit:       0.0,
 				PolygonSegments: conf.Layers[idx].WcsPolygonSegments,
 				GrpcConcLimit:   conf.Layers[idx].GrpcWcsConcPerNode,
+				QueryLimit:      -1,
 			},
 				Collection: styleLayer.DataSource,
 				CRS:        *params.CRS,
@@ -784,7 +785,7 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 			select {
 			case res := <-tp.Process(geoReq, *verbose):
 				if !isInit {
-					hDstDS, masterTempFile, err = utils.EncodeGdalOpen(conf.ServiceConfig.TempDir, 1024, 256, driverFormat, geot, epsg, res, *params.Width, *params.Height, len(conf.Layers[idx].RGBProducts))
+					hDstDS, masterTempFile, err = utils.EncodeGdalOpen(conf.ServiceConfig.TempDir, 1024, 256, driverFormat, geot, epsg, res, *params.Width, *params.Height, len(styleLayer.RGBProducts))
 					if err != nil {
 						os.Remove(masterTempFile)
 						errMsg := fmt.Sprintf("EncodeGdalOpen() failed: %v", err)

--- a/ows.go
+++ b/ows.go
@@ -223,19 +223,31 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			return
 		}
 
-		geoReq := &proc.GeoTileRequest{ConfigPayLoad: proc.ConfigPayLoad{NameSpaces: conf.Layers[idx].RGBProducts,
-			Mask:    conf.Layers[idx].Mask,
-			Palette: conf.Layers[idx].Palette,
-			ScaleParams: proc.ScaleParams{Offset: conf.Layers[idx].OffsetValue,
-				Scale: conf.Layers[idx].ScaleValue,
-				Clip:  conf.Layers[idx].ClipValue,
+		styleIdx, err := utils.GetLayerStyleIndex(params, conf, idx)
+		if err != nil {
+			Error.Printf("%s\n", err)
+			http.Error(w, fmt.Sprintf("Malformed WMS GetMap request: %v", err), 400)
+			return
+		}
+
+		styleLayer := &conf.Layers[idx]
+		if styleIdx >= 0 {
+			styleLayer = &conf.Layers[idx].Styles[styleIdx]
+		}
+
+		geoReq := &proc.GeoTileRequest{ConfigPayLoad: proc.ConfigPayLoad{NameSpaces: styleLayer.RGBProducts,
+			Mask:    styleLayer.Mask,
+			Palette: styleLayer.Palette,
+			ScaleParams: proc.ScaleParams{Offset: styleLayer.OffsetValue,
+				Scale: styleLayer.ScaleValue,
+				Clip:  styleLayer.ClipValue,
 			},
 			ZoomLimit:       conf.Layers[idx].ZoomLimit,
 			PolygonSegments: conf.Layers[idx].WmsPolygonSegments,
 			GrpcConcLimit:   conf.Layers[idx].GrpcWmsConcPerNode,
 			QueryLimit:      -1,
 		},
-			Collection: conf.Layers[idx].DataSource,
+			Collection: styleLayer.DataSource,
 			CRS:        *params.CRS,
 			BBox:       params.BBox,
 			Height:     *params.Height,
@@ -336,7 +348,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 				return
 			}
 
-			out, err := utils.EncodePNG(norm, conf.Layers[idx].Palette)
+			out, err := utils.EncodePNG(norm, styleLayer.Palette)
 			if err != nil {
 				Info.Printf("Error in the utils.EncodePNG: %v\n", err)
 				http.Error(w, err.Error(), 500)
@@ -367,10 +379,21 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			}
 			return
 		}
-
-		b, err := ioutil.ReadFile(conf.Layers[idx].LegendPath)
+		styleIdx, err := utils.GetLayerStyleIndex(params, conf, idx)
 		if err != nil {
-			Error.Printf("Error reading legend image: %v, %v\n", conf.Layers[idx].LegendPath, err)
+			Error.Printf("%s\n", err)
+			http.Error(w, fmt.Sprintf("Malformed WMS GetMap request: %v", err), 400)
+			return
+		}
+
+		styleLayer := &conf.Layers[idx]
+		if styleIdx >= 0 {
+			styleLayer = &conf.Layers[idx].Styles[styleIdx]
+		}
+
+		b, err := ioutil.ReadFile(styleLayer.LegendPath)
+		if err != nil {
+			Error.Printf("Error reading legend image: %v, %v\n", styleLayer.LegendPath, err)
 			http.Error(w, "Legend graphics not found", 500)
 			return
 		}
@@ -465,6 +488,18 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 			endTime = &eT
 		}
 
+		styleIdx, err := utils.GetCoverageStyleIndex(params, conf, idx)
+		if err != nil {
+			Error.Printf("%s\n", err)
+			http.Error(w, fmt.Sprintf("Malformed WMS GetMap request: %v", err), 400)
+			return
+		}
+
+		styleLayer := &conf.Layers[idx]
+		if styleIdx >= 0 {
+			styleLayer = &conf.Layers[idx].Styles[styleIdx]
+		}
+
 		maxXTileSize := 1024
 		maxYTileSize := 1024
 		checkpointThreshold := 300
@@ -476,18 +511,18 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 		_, isWorker := query["wbbox"]
 
 		getGeoTileRequest := func(width int, height int, bbox []float64, offX int, offY int) *proc.GeoTileRequest {
-			geoReq := &proc.GeoTileRequest{ConfigPayLoad: proc.ConfigPayLoad{NameSpaces: conf.Layers[idx].RGBProducts,
-				Mask:    conf.Layers[idx].Mask,
-				Palette: conf.Layers[idx].Palette,
-				ScaleParams: proc.ScaleParams{Offset: conf.Layers[idx].OffsetValue,
-					Scale: conf.Layers[idx].ScaleValue,
-					Clip:  conf.Layers[idx].ClipValue,
+			geoReq := &proc.GeoTileRequest{ConfigPayLoad: proc.ConfigPayLoad{NameSpaces: styleLayer.RGBProducts,
+				Mask:    styleLayer.Mask,
+				Palette: styleLayer.Palette,
+				ScaleParams: proc.ScaleParams{Offset: styleLayer.OffsetValue,
+					Scale: styleLayer.ScaleValue,
+					Clip:  styleLayer.ClipValue,
 				},
 				ZoomLimit:       0.0,
 				PolygonSegments: conf.Layers[idx].WcsPolygonSegments,
 				GrpcConcLimit:   conf.Layers[idx].GrpcWcsConcPerNode,
 			},
-				Collection: conf.Layers[idx].DataSource,
+				Collection: styleLayer.DataSource,
 				CRS:        *params.CRS,
 				BBox:       bbox,
 				Height:     height,

--- a/processor/feature_info.go
+++ b/processor/feature_info.go
@@ -155,7 +155,9 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	}
 
 	var namespaces []string
-	if len(conf.Layers[idx].FeatureInfoBands) > 0 {
+	if len(styleLayer.FeatureInfoBands) > 0 {
+		namespaces = styleLayer.FeatureInfoBands
+	} else if len(conf.Layers[idx].FeatureInfoBands) > 0 {
 		namespaces = conf.Layers[idx].FeatureInfoBands
 	} else {
 		namespaces = styleLayer.RGBProducts

--- a/templates/WMS_GetCapabilities.tpl
+++ b/templates/WMS_GetCapabilities.tpl
@@ -117,9 +117,9 @@
 						<Title>{{ .Title }}</Title>
 						<Abstract>{{ .Abstract }}</Abstract>
 						{{if .LegendPath }}
-						<LegendURL width="160" height="424">
+						<LegendURL width="{{ .LegendWidth }}" height="{{ .LegendHeight }}">
 							<Format>image/png</Format>
-							<OnlineResource xlink:type="simple" xlink:href="http://{{ .OWSHostname }}/ows/{{ .NameSpace }}?service=WMS&amp;request=GetLegendGraphic&amp;version=1.3.0&amp;layers={{ .Name }}"/>
+							<OnlineResource xlink:type="simple" xlink:href="http://{{ .OWSHostname }}/ows/{{ .NameSpace }}?service=WMS&amp;request=GetLegendGraphic&amp;version=1.3.0&amp;layers={{ $value.Name }}&amp;styles={{ .Name }}"/>
 						</LegendURL>
 						{{end}}
 					</Style>

--- a/templates/WMS_GetCapabilities.tpl
+++ b/templates/WMS_GetCapabilities.tpl
@@ -110,17 +110,20 @@
 					<Format>text/plain</Format>
 					<OnlineResource xlink:type="simple" xlink:href="{{ .DataURL }}"/>
 				</DataURL>
-				<Style>
-					<Name>{{ .Name }}</Name>
-					<Title>{{ .Title }}</Title>
-					<Abstract>A sample style that draws a raster, good for displaying imagery</Abstract>
-					{{if .LegendPath }}
-					<LegendURL width="160" height="424">
-						<Format>image/png</Format>
-						<OnlineResource xlink:type="simple" xlink:href="http://{{ .OWSHostname }}/ows/{{ .NameSpace }}?service=WMS&amp;request=GetLegendGraphic&amp;version=1.3.0&amp;layers={{ .Name }}"/>
-					</LegendURL>
-					{{end}}
-				</Style>
+				
+				{{ range $styleIdx, $style := $value.Styles }}
+					<Style>
+						<Name>{{ .Name }}</Name>
+						<Title>{{ .Title }}</Title>
+						<Abstract>{{ .Abstract }}</Abstract>
+						{{if .LegendPath }}
+						<LegendURL width="160" height="424">
+							<Format>image/png</Format>
+							<OnlineResource xlink:type="simple" xlink:href="http://{{ .OWSHostname }}/ows/{{ .NameSpace }}?service=WMS&amp;request=GetLegendGraphic&amp;version=1.3.0&amp;layers={{ .Name }}"/>
+						</LegendURL>
+						{{end}}
+					</Style>
+				{{end}}
 			</Layer>
 			{{end}}
 		</Layer>

--- a/utils/config.go
+++ b/utils/config.go
@@ -446,7 +446,6 @@ func LoadAllConfigFiles(rootDir string, verbose bool) (map[string]*Config, error
 					if config.Layers[i].Styles[j].LegendWidth <= 0 {
 						config.Layers[i].Styles[j].LegendWidth = DefaultLegendWidth
 					}
-
 					if config.Layers[i].Styles[j].LegendHeight <= 0 {
 						config.Layers[i].Styles[j].LegendHeight = DefaultLegendHeight
 					}
@@ -772,7 +771,6 @@ func (config *Config) LoadConfigFile(configFile string, verbose bool) error {
 		if config.Layers[i].WcsMaxHeight <= 0 {
 			config.Layers[i].WcsMaxHeight = DefaultWcsMaxHeight
 		}
-
 	}
 
 	for i, proc := range config.Processes {

--- a/utils/config.go
+++ b/utils/config.go
@@ -90,6 +90,8 @@ type Layer struct {
 	ScaleValue               float64  `json:"scale_value"`
 	Palette                  *Palette `json:"palette"`
 	LegendPath               string   `json:"legend_path"`
+	LegendHeight             int      `json:"legend_height"`
+	LegendWidth              int      `json:"legend_width"`
 	Styles                   []Layer  `json:"styles"`
 	ZoomLimit                float64  `json:"zoom_limit"`
 	MaxGrpcRecvMsgSize       int      `json:"max_grpc_recv_msg_size"`
@@ -441,8 +443,14 @@ func LoadAllConfigFiles(rootDir string, verbose bool) (map[string]*Config, error
 					if len(config.Layers[i].Styles[j].DataSource) == 0 {
 						config.Layers[i].Styles[j].DataSource = config.Layers[i].DataSource
 					}
-				}
+					if config.Layers[i].Styles[j].LegendWidth <= 0 {
+						config.Layers[i].Styles[j].LegendWidth = DefaultLegendWidth
+					}
 
+					if config.Layers[i].Styles[j].LegendHeight <= 0 {
+						config.Layers[i].Styles[j].LegendHeight = DefaultLegendHeight
+					}
+				}
 			}
 		}
 		return nil
@@ -507,6 +515,9 @@ const DefaultWmsMaxWidth = 512
 const DefaultWmsMaxHeight = 512
 const DefaultWcsMaxWidth = 50000
 const DefaultWcsMaxHeight = 30000
+
+const DefaultLegendWidth = 160
+const DefaultLegendHeight = 320
 
 // GetLayerDates loads dates for the ith layer
 func (config *Config) GetLayerDates(iLayer int, verbose bool) {

--- a/utils/config.go
+++ b/utils/config.go
@@ -90,6 +90,7 @@ type Layer struct {
 	ScaleValue               float64  `json:"scale_value"`
 	Palette                  *Palette `json:"palette"`
 	LegendPath               string   `json:"legend_path"`
+	Styles                   []Layer  `json:"styles"`
 	ZoomLimit                float64  `json:"zoom_limit"`
 	MaxGrpcRecvMsgSize       int      `json:"max_grpc_recv_msg_size"`
 	WmsPolygonSegments       int      `json:"wms_polygon_segments"`
@@ -434,6 +435,14 @@ func LoadAllConfigFiles(rootDir string, verbose bool) (map[string]*Config, error
 					ns = ""
 				}
 				config.Layers[i].NameSpace = ns
+				for j := range config.Layers[i].Styles {
+					config.Layers[i].Styles[j].OWSHostname = config.Layers[i].OWSHostname
+					config.Layers[i].Styles[j].NameSpace = config.Layers[i].NameSpace
+					if len(config.Layers[i].Styles[j].DataSource) == 0 {
+						config.Layers[i].Styles[j].DataSource = config.Layers[i].DataSource
+					}
+				}
+
 			}
 		}
 		return nil
@@ -752,6 +761,7 @@ func (config *Config) LoadConfigFile(configFile string, verbose bool) error {
 		if config.Layers[i].WcsMaxHeight <= 0 {
 			config.Layers[i].WcsMaxHeight = DefaultWcsMaxHeight
 		}
+
 	}
 
 	for i, proc := range config.Processes {

--- a/utils/wcs.go
+++ b/utils/wcs.go
@@ -157,7 +157,11 @@ func GetCoverageStyleIndex(params WCSParams, config *Config, covIdx int) (int, e
 	if params.Styles != nil {
 		style := strings.TrimSpace(params.Styles[0])
 		if len(style) == 0 {
-			return -1, nil
+			if len(config.Layers[covIdx].Styles) > 0 {
+				return 0, nil
+			} else {
+				return -1, nil
+			}
 		}
 		for i := range config.Layers[covIdx].Styles {
 			if config.Layers[covIdx].Styles[i].Name == style {

--- a/utils/wcs.go
+++ b/utils/wcs.go
@@ -22,6 +22,7 @@ type WCSParams struct {
 	Height    *int       `json:"height,omitempty"`
 	Width     *int       `json:"width,omitempty"`
 	Format    *string    `json:"format,omitempty"`
+	Styles    []string   `json:"styles,omitempty"`
 }
 
 // WCSRegexpMap maps WCS request parameters to
@@ -121,6 +122,12 @@ func WCSParamsChecker(params map[string][]string, compREMap map[string]*regexp.R
 		}
 	}
 
+	if styles, stylesOK := params["styles"]; stylesOK {
+		if !strings.Contains(styles[0], "\"") {
+			jsonFields = append(jsonFields, fmt.Sprintf(`"styles":["%s"]`, strings.Replace(styles[0], ",", "\",\"", -1)))
+		}
+	}
+
 	jsonParams := fmt.Sprintf("{%s}", strings.Join(jsonFields, ","))
 
 	var wcsParams WCSParams
@@ -142,4 +149,26 @@ func GetCoverageIndex(params WCSParams, config *Config) (int, error) {
 		return -1, fmt.Errorf("%s not found in config Layers", product)
 	}
 	return -1, fmt.Errorf("WCS request doesn't specify a product")
+}
+
+// GetCoverageStyleIndex returns the index of the
+// specified style inside a coverage
+func GetCoverageStyleIndex(params WCSParams, config *Config, covIdx int) (int, error) {
+	if params.Styles != nil {
+		style := strings.TrimSpace(params.Styles[0])
+		if len(style) == 0 {
+			return -1, nil
+		}
+		for i := range config.Layers[covIdx].Styles {
+			if config.Layers[covIdx].Styles[i].Name == style {
+				return i, nil
+			}
+		}
+		return -1, fmt.Errorf("style %s not found in this coverage", style)
+	} else {
+		if len(config.Layers[covIdx].Styles) > 0 {
+			return 0, nil
+		}
+	}
+	return -1, nil
 }

--- a/utils/wms.go
+++ b/utils/wms.go
@@ -211,7 +211,11 @@ func GetLayerStyleIndex(params WMSParams, config *Config, layerIdx int) (int, er
 	if params.Styles != nil {
 		style := strings.TrimSpace(params.Styles[0])
 		if len(style) == 0 {
-			return -1, nil
+			if len(config.Layers[layerIdx].Styles) > 0 {
+				return 0, nil
+			} else {
+				return -1, nil
+			}
 		}
 		for i := range config.Layers[layerIdx].Styles {
 			if config.Layers[layerIdx].Styles[i].Name == style {

--- a/utils/wms.go
+++ b/utils/wms.go
@@ -205,6 +205,28 @@ func GetLayerIndex(params WMSParams, config *Config) (int, error) {
 	return -1, fmt.Errorf("WMS request doesn't specify a product")
 }
 
+// GetLayerStyleIndex returns the index of the
+// specified style inside a layer
+func GetLayerStyleIndex(params WMSParams, config *Config, layerIdx int) (int, error) {
+	if params.Styles != nil {
+		style := strings.TrimSpace(params.Styles[0])
+		if len(style) == 0 {
+			return -1, nil
+		}
+		for i := range config.Layers[layerIdx].Styles {
+			if config.Layers[layerIdx].Styles[i].Name == style {
+				return i, nil
+			}
+		}
+		return -1, fmt.Errorf("style %s not found in this layer", style)
+	} else {
+		if len(config.Layers[layerIdx].Styles) > 0 {
+			return 0, nil
+		}
+	}
+	return -1, nil
+}
+
 func ExecuteWriteTemplateFile(w io.Writer, data interface{}, filePath string) error {
 	// General template compilation, execution and writting in to
 	// a stream.


### PR DESCRIPTION
The OGC WMS standard supports defining one or more "styles" in a layer which allows different views of the same layer (eg. false and true colour). Currently GSKY only supports a flat namespace of layer definitions without styles so we have to emulate this by generating a layer for every possible layer and style combination. While we have reduced the amount of repetition required for the catalog generation, this doesn't solve the following client side issues:
* Users are presented with a confusingly long list of layers where most of them are variants of the same layer.
* The payload size of GetCapabilities is much larger than it needs to be because lots of attributes (eg. timestamp list) have to be repeated in each layer definition.
* The NationalMap/TerriaJS UI allows users to easily switch between styles within a given layer compared to GSKY users having to load multiple layers.

We should modify the GSKY configuration schema to include one or more styles for each layer, where the attributes that are relevant to a particular view of the data are defined in each style and the common invariant attributes are defined at layer level. For example:

```
  "layers": [
    {
      "abstract": "...",
      "accum": true,
      "data_source": "/g/data2/rs0/datacube/002/LS5_TM_NBAR",
      "end_isodate": "mas",
      "name": "ls5_nbar",
      "styles": [
        {
          "abstract": "Description of false colour",
          "clip_value": 4500,
          "name": "fc",
          "offset_value": 0,
          "rgb_products": [
            "swir1",
            "nir",
            "green"
          ],
          "scale_value": 0.0566,
          "title": "False Colour"
        },
        {
          "abstract": "Description of true colour",
          "clip_value": 2500,
          "name": "tc",
          "offset_value": 0,
          "rgb_products": [
            "red",
            "green",
            "blue"
          ],
          "scale_value": 0.1016,
          "title": "True Colour"
        }
      ],
      "start_isodate": "mas",
      "step_days": 16,
      "time_generator": "regular",
      "title": "16-day DEA Landsat 5 surface reflectance",
      "wcs_timeout": 180,
      "zoom_limit": 650
    }
  ]
```
