### PR TITLE
added configurable max grpc buffer size

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -322,7 +322,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 		timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Duration(conf.Layers[idx].WmsTimeout)*time.Second)
 		defer timeoutCancel()
 
-		tp := proc.InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, conf.ServiceConfig.WorkerNodes, conf.Layers[idx].MaxGrpcRecvMsgSize, conf.Layers[idx].WmsPolygonShardConcLimit, errChan)
+		tp := proc.InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, conf.ServiceConfig.WorkerNodes, conf.Layers[idx].MaxGrpcRecvMsgSize, conf.Layers[idx].WmsPolygonShardConcLimit, conf.ServiceConfig.MaxGrpcBufferSize, errChan)
 		select {
 		case res := <-tp.Process(geoReq, *verbose):
 			scaleParams := utils.ScaleParams{Offset: geoReq.ScaleParams.Offset,
@@ -776,7 +776,7 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 
 		isInit := false
 
-		tp := proc.InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, conf.ServiceConfig.WorkerNodes, conf.Layers[idx].MaxGrpcRecvMsgSize, conf.Layers[idx].WcsPolygonShardConcLimit, errChan)
+		tp := proc.InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, conf.ServiceConfig.WorkerNodes, conf.Layers[idx].MaxGrpcRecvMsgSize, conf.Layers[idx].WcsPolygonShardConcLimit, conf.ServiceConfig.MaxGrpcBufferSize, errChan)
 		for ir, geoReq := range workerTileRequests[0] {
 			if *verbose {
 				Info.Printf("WCS: processing tile (%d of %d): xOff:%v, yOff:%v, width:%v, height:%v", ir+1, len(workerTileRequests[0]), geoReq.OffX, geoReq.OffY, geoReq.Width, geoReq.Height)

--- a/processor/feature_info.go
+++ b/processor/feature_info.go
@@ -216,7 +216,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	errChan := make(chan error, 100)
 
 	var outRaster []utils.Raster
-	tp := InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, conf.ServiceConfig.WorkerNodes, conf.Layers[idx].MaxGrpcRecvMsgSize, conf.Layers[idx].WmsPolygonShardConcLimit, errChan)
+	tp := InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, conf.ServiceConfig.WorkerNodes, conf.Layers[idx].MaxGrpcRecvMsgSize, conf.Layers[idx].WmsPolygonShardConcLimit, conf.ServiceConfig.MaxGrpcBufferSize, errChan)
 	select {
 	case res := <-tp.Process(geoReq, verbose):
 		outRaster = res

--- a/processor/tile_pipeline.go
+++ b/processor/tile_pipeline.go
@@ -12,9 +12,10 @@ type TilePipeline struct {
 	MaxGrpcRecvMsgSize    int
 	PolygonShardConcLimit int
 	MASAddress            string
+	MaxGrpcBufferSize     int
 }
 
-func InitTilePipeline(ctx context.Context, masAddr string, rpcAddr []string, maxGrpcRecvMsgSize int, polygonShardConcLimit int, errChan chan error) *TilePipeline {
+func InitTilePipeline(ctx context.Context, masAddr string, rpcAddr []string, maxGrpcRecvMsgSize int, polygonShardConcLimit int, maxGrpcBufferSize int, errChan chan error) *TilePipeline {
 	return &TilePipeline{
 		Context:               ctx,
 		Error:                 errChan,
@@ -22,11 +23,12 @@ func InitTilePipeline(ctx context.Context, masAddr string, rpcAddr []string, max
 		MaxGrpcRecvMsgSize:    maxGrpcRecvMsgSize,
 		PolygonShardConcLimit: polygonShardConcLimit,
 		MASAddress:            masAddr,
+		MaxGrpcBufferSize:     maxGrpcBufferSize,
 	}
 }
 
 func (dp *TilePipeline) Process(geoReq *GeoTileRequest, verbose bool) chan []utils.Raster {
-	grpcTiler := NewRasterGRPC(dp.Context, dp.RPCAddress, dp.MaxGrpcRecvMsgSize, dp.PolygonShardConcLimit, dp.Error)
+	grpcTiler := NewRasterGRPC(dp.Context, dp.RPCAddress, dp.MaxGrpcRecvMsgSize, dp.PolygonShardConcLimit, dp.MaxGrpcBufferSize, dp.Error)
 
 	i := NewTileIndexer(dp.Context, dp.MASAddress, dp.Error)
 	go func() {

--- a/utils/config.go
+++ b/utils/config.go
@@ -26,12 +26,13 @@ var DataDir = "."
 const ReservedMemorySize = 1.5 * 1024 * 1024 * 1024
 
 type ServiceConfig struct {
-	OWSHostname     string `json:"ows_hostname"`
-	NameSpace       string
-	MASAddress      string   `json:"mas_address"`
-	WorkerNodes     []string `json:"worker_nodes"`
-	OWSClusterNodes []string `json:"ows_cluster_nodes"`
-	TempDir         string   `json:"temp_dir"`
+	OWSHostname       string `json:"ows_hostname"`
+	NameSpace         string
+	MASAddress        string   `json:"mas_address"`
+	WorkerNodes       []string `json:"worker_nodes"`
+	OWSClusterNodes   []string `json:"ows_cluster_nodes"`
+	TempDir           string   `json:"temp_dir"`
+	MaxGrpcBufferSize int      `json:"max_grpc_buffer_size"`
 }
 
 // CacheLevel contains the source files of one layer as well as the
@@ -711,6 +712,13 @@ func (config *Config) LoadConfigFile(configFile string, verbose bool) error {
 			return fmt.Errorf("error creating temp directory: %v", err)
 		}
 	}
+
+	if config.ServiceConfig.MaxGrpcBufferSize > 0 && config.ServiceConfig.MaxGrpcBufferSize < 10 {
+		config.ServiceConfig.MaxGrpcBufferSize = 0
+		log.Printf("%v: MaxGrpcBufferSize is set to less than 10MB, reset to unlimited", configFile)
+	}
+
+	config.ServiceConfig.MaxGrpcBufferSize = config.ServiceConfig.MaxGrpcBufferSize * 1024 * 1024
 
 	for i, layer := range config.Layers {
 		config.GetLayerDates(i, verbose)


### PR DESCRIPTION
Currently GSKY tries to limit memory usage by comparing how much it thinks it will need for a given request vs. how much system memory is left at that time. This approach has an in-built race condition and often the OOM killer is triggered anyway. So after discussion we decided that we'll change this test to instead compare the predicted maximum request memory usage against a global limit set in the configuration. Any request (whether WCS or WMS) exceeding that limit will be rejected. The intention here is solely to prevent requests that are considered to be unacceptably large.