### PR TITLE
added support for singular layer

### DIFF
--- a/utils/wms.go
+++ b/utils/wms.go
@@ -156,7 +156,15 @@ func WMSParamsChecker(params map[string][]string, compREMap map[string]*regexp.R
 		}
 	}
 
-	if layers, layersOK := params["layers"]; layersOK {
+	var layers []string
+	if _layers, layersOK := params["layers"]; layersOK {
+		layers = _layers
+	} else {
+		if _layer, layerOK := params["layer"]; layerOK {
+			layers = _layer
+		}
+	}
+	if len(layers) > 0 {
 		if !strings.Contains(layers[0], "\"") {
 			jsonFields = append(jsonFields, fmt.Sprintf(`"layers":["%s"]`, strings.Replace(layers[0], ",", "\",\"", -1)))
 		}


### PR DESCRIPTION
The WMS GetLegendGraphics operation sometimes use the singular version of the layers parameter (i.e. layer vs layers). Currently GSKY only supports layers instead of layer. Thus we need to support both of them to cater for GetLegendGraphics from the clients who use the singular version.