### PR TITLE
added support for band maths

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -235,9 +235,10 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			styleLayer = &conf.Layers[idx].Styles[styleIdx]
 		}
 
-		geoReq := &proc.GeoTileRequest{ConfigPayLoad: proc.ConfigPayLoad{NameSpaces: styleLayer.RGBProducts,
-			Mask:    styleLayer.Mask,
-			Palette: styleLayer.Palette,
+		geoReq := &proc.GeoTileRequest{ConfigPayLoad: proc.ConfigPayLoad{NameSpaces: styleLayer.RGBExpressions.VarList,
+			BandExpr: styleLayer.RGBExpressions,
+			Mask:     styleLayer.Mask,
+			Palette:  styleLayer.Palette,
 			ScaleParams: proc.ScaleParams{Offset: styleLayer.OffsetValue,
 				Scale: styleLayer.ScaleValue,
 				Clip:  styleLayer.ClipValue,
@@ -511,9 +512,10 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 		_, isWorker := query["wbbox"]
 
 		getGeoTileRequest := func(width int, height int, bbox []float64, offX int, offY int) *proc.GeoTileRequest {
-			geoReq := &proc.GeoTileRequest{ConfigPayLoad: proc.ConfigPayLoad{NameSpaces: styleLayer.RGBProducts,
-				Mask:    styleLayer.Mask,
-				Palette: styleLayer.Palette,
+			geoReq := &proc.GeoTileRequest{ConfigPayLoad: proc.ConfigPayLoad{NameSpaces: styleLayer.RGBExpressions.VarList,
+				BandExpr: styleLayer.RGBExpressions,
+				Mask:     styleLayer.Mask,
+				Palette:  styleLayer.Palette,
 				ScaleParams: proc.ScaleParams{Offset: styleLayer.OffsetValue,
 					Scale: styleLayer.ScaleValue,
 					Clip:  styleLayer.ClipValue,

--- a/processor/drill_merger.go
+++ b/processor/drill_merger.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"sort"
 
-	goeval "github.com/Knetic/govaluate"
+	goeval "github.com/edisonguo/govaluate"
 	"github.com/nci/gsky/utils"
 	pb "github.com/nci/gsky/worker/gdalservice"
 )
@@ -150,13 +150,13 @@ func (dm *DrillMerger) Run(suffix string, namespaces []string, templateFileName 
 				return
 			}
 
-			val, ok := result.(float64)
+			val, ok := result.(float32)
 			if !ok {
-				dm.Error <- fmt.Errorf("WPS: Failed to cast eval results '%v' to float64, %v", val, bandEval[iv])
+				dm.Error <- fmt.Errorf("WPS: Failed to cast eval results '%v' to float323232, %v", val, bandEval[iv])
 				return
 			}
 
-			fmt.Fprintf(csv, "%f", val)
+			fmt.Fprintf(csv, "%f", float64(val))
 		}
 
 		fmt.Fprint(csv, "\\n")

--- a/processor/feature_info.go
+++ b/processor/feature_info.go
@@ -168,7 +168,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	}
 
 	if conf.Layers[idx].ZoomLimit != 0.0 && reqRes > conf.Layers[idx].ZoomLimit {
-		return []utils.Raster{&utils.ByteRaster{NameSpace: "ZoomOut"}}, namespaces, nil, nil
+		return []utils.Raster{&utils.ByteRaster{NameSpace: "ZoomOut"}}, bandExpr.ExprNames, nil, nil
 	}
 
 	if params.Height == nil || params.Width == nil {

--- a/processor/feature_info.go
+++ b/processor/feature_info.go
@@ -155,12 +155,16 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	}
 
 	var namespaces []string
+	var bandExpr *utils.BandExpressions
 	if len(styleLayer.FeatureInfoBands) > 0 {
-		namespaces = styleLayer.FeatureInfoBands
+		namespaces = styleLayer.FeatureInfoExpressions.VarList
+		bandExpr = styleLayer.FeatureInfoExpressions
 	} else if len(conf.Layers[idx].FeatureInfoBands) > 0 {
-		namespaces = conf.Layers[idx].FeatureInfoBands
+		namespaces = conf.Layers[idx].FeatureInfoExpressions.VarList
+		bandExpr = conf.Layers[idx].FeatureInfoExpressions
 	} else {
-		namespaces = styleLayer.RGBProducts
+		namespaces = styleLayer.RGBExpressions.VarList
+		bandExpr = styleLayer.RGBExpressions
 	}
 
 	if conf.Layers[idx].ZoomLimit != 0.0 && reqRes > conf.Layers[idx].ZoomLimit {
@@ -196,6 +200,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	}
 
 	geoReq := &GeoTileRequest{ConfigPayLoad: ConfigPayLoad{NameSpaces: namespaces,
+		BandExpr:        bandExpr,
 		Mask:            styleLayer.Mask,
 		ZoomLimit:       conf.Layers[idx].ZoomLimit,
 		PolygonSegments: conf.Layers[idx].WmsPolygonSegments,
@@ -227,7 +232,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	}
 
 	if conf.Layers[idx].FeatureInfoMaxDataLinks < 1 {
-		return outRaster, namespaces, nil, nil
+		return outRaster, bandExpr.ExprNames, nil, nil
 	}
 
 	x, y, err := utils.GetCoordinates(params)
@@ -297,5 +302,5 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 		}
 	}
 
-	return outRaster, namespaces, topDsFiles, nil
+	return outRaster, bandExpr.ExprNames, topDsFiles, nil
 }

--- a/processor/tile_grpc.go
+++ b/processor/tile_grpc.go
@@ -41,13 +41,14 @@ func NewRasterGRPC(ctx context.Context, serverAddress []string, maxGrpcRecvMsgSi
 	}
 }
 
-func (gi *GeoRasterGRPC) Run(polyLimiter *ConcLimiter, verbose bool) {
+func (gi *GeoRasterGRPC) Run(polyLimiter *ConcLimiter, varList []string, verbose bool) {
 	if verbose {
 		defer log.Printf("tile grpc done")
 	}
 	defer close(gi.Out)
 
 	var grans []*GeoTileGranule
+	availNamespaces := make(map[string]bool)
 	i := 0
 	imageSize := 0
 	for gran := range gi.In {
@@ -61,12 +62,23 @@ func (gi *GeoRasterGRPC) Run(polyLimiter *ConcLimiter, verbose bool) {
 				imageSize = gran.Height * gran.Width
 			}
 
+			if _, found := availNamespaces[gran.NameSpace]; !found {
+				availNamespaces[gran.NameSpace] = true
+			}
+
 			i++
 		}
 	}
 
 	if len(grans) == 0 {
 		return
+	}
+
+	for _, v := range varList {
+		if _, found := availNamespaces[v]; !found {
+			gi.sendError(fmt.Errorf("band '%v' not found", v))
+			return
+		}
 	}
 
 	g0 := grans[0]

--- a/processor/tile_merger.go
+++ b/processor/tile_merger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log"
+	"math"
 	"reflect"
 	"sort"
 	"strconv"
@@ -527,7 +528,11 @@ func (enc *RasterMerger) Run(polyLimiter *ConcLimiter, bandExpr *utils.BandExpre
 			if isArr {
 				for i := range outRaster.Data {
 					if noDataMasks[i] {
-						outRaster.Data[i] = resArr[i]
+						if math.IsInf(float64(resArr[i]), 0) || math.IsNaN(float64(resArr[i])) {
+							outRaster.Data[i] = float32(noData)
+						} else {
+							outRaster.Data[i] = resArr[i]
+						}
 					} else {
 						outRaster.Data[i] = float32(noData)
 					}

--- a/processor/tile_pipeline.go
+++ b/processor/tile_pipeline.go
@@ -41,7 +41,7 @@ func (dp *TilePipeline) Process(geoReq *GeoTileRequest, verbose bool) chan []uti
 
 	polyLimiter := NewConcLimiter(dp.PolygonShardConcLimit)
 	go i.Run(verbose)
-	go grpcTiler.Run(polyLimiter, verbose)
+	go grpcTiler.Run(polyLimiter, geoReq.BandExpr.VarList, verbose)
 	go m.Run(polyLimiter, geoReq.BandExpr, verbose)
 
 	return m.Out

--- a/processor/tile_pipeline.go
+++ b/processor/tile_pipeline.go
@@ -42,7 +42,7 @@ func (dp *TilePipeline) Process(geoReq *GeoTileRequest, verbose bool) chan []uti
 	polyLimiter := NewConcLimiter(dp.PolygonShardConcLimit)
 	go i.Run(verbose)
 	go grpcTiler.Run(polyLimiter, verbose)
-	go m.Run(polyLimiter, verbose)
+	go m.Run(polyLimiter, geoReq.BandExpr, verbose)
 
 	return m.Out
 

--- a/processor/tile_types.go
+++ b/processor/tile_types.go
@@ -14,6 +14,7 @@ type ScaleParams struct {
 
 type ConfigPayLoad struct {
 	NameSpaces            []string
+	BandExpr              *utils.BandExpressions
 	ScaleParams           ScaleParams
 	Palette               *utils.Palette
 	Mask                  *utils.Mask

--- a/utils/config.go
+++ b/utils/config.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/CloudyKit/jet"
+	goeval "github.com/edisonguo/govaluate"
 )
 
 var EtcDir = "."
@@ -59,6 +60,13 @@ type Palette struct {
 	Colours     []color.RGBA `json:"colours"`
 }
 
+type BandExpressions struct {
+	ExprText    []string
+	Expressions []*goeval.EvaluableExpression
+	VarList     []string
+	ExprNames   []string
+}
+
 // Layer contains all the details that a layer needs
 // to be published and rendered
 type Layer struct {
@@ -84,6 +92,7 @@ type Layer struct {
 	ResFilter                *int     `json:"resolution_filter"`
 	Dates                    []string `json:"dates"`
 	RGBProducts              []string `json:"rgb_products"`
+	RGBExpressions           *BandExpressions
 	Mask                     *Mask    `json:"mask"`
 	OffsetValue              float64  `json:"offset_value"`
 	ClipValue                float64  `json:"clip_value"`
@@ -112,6 +121,7 @@ type Layer struct {
 	FeatureInfoMaxDataLinks  int      `json:"feature_info_max_data_links"`
 	FeatureInfoDataLinkUrl   string   `json:"feature_info_data_link_url"`
 	FeatureInfoBands         []string `json:"feature_info_bands"`
+	FeatureInfoExpressions   *BandExpressions
 }
 
 // Process contains all the details that a WPS needs
@@ -524,7 +534,7 @@ func (config *Config) GetLayerDates(iLayer int, verbose bool) {
 	step := time.Minute * time.Duration(60*24*layer.StepDays+60*layer.StepHours+layer.StepMinutes)
 
 	if strings.TrimSpace(strings.ToLower(layer.TimeGen)) == "mas" {
-		timestamps, token := GenerateDatesMas(layer.StartISODate, layer.EndISODate, config.ServiceConfig.MASAddress, layer.DataSource, layer.RGBProducts, step, layer.TimestampToken, verbose)
+		timestamps, token := GenerateDatesMas(layer.StartISODate, layer.EndISODate, config.ServiceConfig.MASAddress, layer.DataSource, layer.RGBExpressions.VarList, step, layer.TimestampToken, verbose)
 		if len(timestamps) > 0 && len(token) > 0 {
 			config.Layers[iLayer].Dates = timestamps
 			config.Layers[iLayer].TimestampToken = token
@@ -556,7 +566,7 @@ func (config *Config) GetLayerDates(iLayer int, verbose bool) {
 		}
 
 		if useMasTimestamps {
-			masTimestamps, token := GenerateDatesMas(startDate, endDate, config.ServiceConfig.MASAddress, layer.DataSource, layer.RGBProducts, 0, layer.TimestampToken, verbose)
+			masTimestamps, token := GenerateDatesMas(startDate, endDate, config.ServiceConfig.MASAddress, layer.DataSource, layer.RGBExpressions.VarList, 0, layer.TimestampToken, verbose)
 			if len(token) == 0 {
 				log.Printf("Failed to get MAS timestamps")
 				return
@@ -624,6 +634,65 @@ func (config *Config) GetLayerDates(iLayer int, verbose bool) {
 		config.Layers[iLayer].EffectiveStartDate = config.Layers[iLayer].Dates[0]
 		config.Layers[iLayer].EffectiveEndDate = config.Layers[iLayer].Dates[nDates-1]
 	}
+}
+
+func ParseBandExpressions(bands []string) (*BandExpressions, error) {
+	bandExpr := &BandExpressions{ExprText: bands}
+	varFound := make(map[string]bool)
+	hasExprAll := false
+	for _, bandRaw := range bands {
+		parts := strings.Split(bandRaw, "=")
+		if len(parts) == 0 {
+			return nil, fmt.Errorf("invalid expression: %v", bandRaw)
+		}
+		for ip, p := range parts {
+			parts[ip] = strings.TrimSpace(p)
+			if len(parts[ip]) == 0 {
+				return nil, fmt.Errorf("invalid expression: %v", bandRaw)
+			}
+		}
+		var band string
+		if len(parts) == 1 {
+			band = parts[0]
+		} else if len(parts) == 2 {
+			band = parts[1]
+		} else {
+			return nil, fmt.Errorf("invalid expression: %v", bandRaw)
+		}
+
+		expr, err := goeval.NewEvaluableExpression(band)
+		if err != nil {
+			return nil, err
+		}
+		bandExpr.Expressions = append(bandExpr.Expressions, expr)
+
+		for _, token := range expr.Tokens() {
+			if token.Kind == goeval.VARIABLE {
+				varName, ok := token.Value.(string)
+				if !ok {
+					return nil, fmt.Errorf("variable token '%v' failed to cast string for band '%v'", token.Value, band)
+				}
+
+				if _, found := varFound[varName]; !found {
+					varFound[varName] = true
+					bandExpr.VarList = append(bandExpr.VarList, varName)
+				}
+			} else {
+				hasExprAll = true
+			}
+		}
+
+		if len(parts) == 1 {
+			bandExpr.ExprNames = append(bandExpr.ExprNames, band)
+		} else if len(parts) == 2 {
+			bandExpr.ExprNames = append(bandExpr.ExprNames, parts[0])
+		}
+	}
+
+	if !hasExprAll {
+		bandExpr.Expressions = nil
+	}
+	return bandExpr, nil
 }
 
 // LoadConfigFileTemplate parses the config as a Jet
@@ -713,7 +782,22 @@ func (config *Config) LoadConfigFile(configFile string, verbose bool) error {
 	}
 
 	for i, layer := range config.Layers {
+		bandExpr, err := ParseBandExpressions(layer.RGBProducts)
+		if err != nil {
+			log.Printf("RGBExpression parsing error: %v", err)
+			bandExpr = &BandExpressions{}
+		}
+		config.Layers[i].RGBExpressions = bandExpr
+
+		featureInfoExpr, err := ParseBandExpressions(layer.FeatureInfoBands)
+		if err != nil {
+			log.Printf("FeatureInfoExpression parsing error: %v", err)
+			featureInfoExpr = &BandExpressions{}
+		}
+		config.Layers[i].FeatureInfoExpressions = featureInfoExpr
+
 		config.GetLayerDates(i, verbose)
+
 		config.Layers[i].OWSHostname = config.ServiceConfig.OWSHostname
 
 		if config.Layers[i].MaxGrpcRecvMsgSize <= DefaultRecvMsgSize {

--- a/utils/config.go
+++ b/utils/config.go
@@ -460,6 +460,22 @@ func LoadAllConfigFiles(rootDir string, verbose bool) (map[string]*Config, error
 					if config.Layers[i].Styles[j].LegendHeight <= 0 {
 						config.Layers[i].Styles[j].LegendHeight = DefaultLegendHeight
 					}
+
+					bandExpr, err := ParseBandExpressions(config.Layers[i].Styles[j].RGBProducts)
+					if err != nil {
+						log.Printf("RGBExpression parsing error: %v", err)
+						bandExpr = &BandExpressions{}
+					}
+					config.Layers[i].Styles[j].RGBExpressions = bandExpr
+
+					if len(config.Layers[i].Styles[j].FeatureInfoBands) > 0 {
+						featureInfoExpr, err := ParseBandExpressions(config.Layers[i].Styles[j].FeatureInfoBands)
+						if err != nil {
+							log.Printf("FeatureInfoExpression parsing error: %v", err)
+							featureInfoExpr = &BandExpressions{}
+						}
+						config.Layers[i].Styles[j].FeatureInfoExpressions = featureInfoExpr
+					}
 				}
 			}
 		}


### PR DESCRIPTION
added support for evaluating arbitrary band maths expressions on the fly. The band maths facility has the following features:

* It does not pose any security risks as the expressions cannot access any IO or system libraries.

* The expressions are evaluated by a light-weight interpreter written in golang which does not require setting up any external code execution environment.

* The arithmetics support element-wise vector operations as well as broadcasting operations between scalars and vectors.

Known limitations:
* Apparently we do not have any built-in maths functions. But we can easily add maths functions when we need them.

 