### PR TITLE
fixed empty minoccurs for wps inputs

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -958,15 +958,17 @@ func serveWPS(ctx context.Context, params utils.WPSParams, conf *utils.Config, r
 			http.Error(w, err.Error(), 500)
 		}
 	case "DescribeProcess":
-		for _, process := range conf.Processes {
-			if process.Identifier == *params.Identifier {
-				err := utils.ExecuteWriteTemplateFile(w, process,
-					utils.DataDir+"/templates/WPS_DescribeProcess.tpl")
-				if err != nil {
-					http.Error(w, err.Error(), 500)
-				}
-				break
-			}
+		idx, err := utils.GetProcessIndex(params, conf)
+		if err != nil {
+			Error.Printf("Requested process not found: %v, %v\n", err, reqURL)
+			http.Error(w, fmt.Sprintf("%v: %s", err, reqURL), 400)
+			return
+		}
+		process := conf.Processes[idx]
+		err = utils.ExecuteWriteTemplateFile(w, process,
+			utils.DataDir+"/templates/WPS_DescribeProcess.tpl")
+		if err != nil {
+			http.Error(w, err.Error(), 500)
 		}
 	case "Execute":
 		idx, err := utils.GetProcessIndex(params, conf)

--- a/utils/config.go
+++ b/utils/config.go
@@ -149,7 +149,7 @@ type LitData struct {
 	DataType      string   `json:"data_type"`
 	DataTypeRef   string   `json:"data_type_ref"`
 	AllowedValues []string `json:"allowed_values"`
-	MinOccurs     string   `json:"min_occurs"`
+	MinOccurs     int      `json:"min_occurs"`
 }
 
 // CompData contains the description of a variable used to compute a
@@ -161,7 +161,7 @@ type CompData struct {
 	MimeType   string `json:"mime_type"`
 	Encoding   string `json:"encoding"`
 	Schema     string `json:"schema"`
-	MinOccurs  string `json:"min_occurs"`
+	MinOccurs  int    `json:"min_occurs"`
 }
 
 // Config is the struct representing the configuration


### PR DESCRIPTION
A WPS input element with empty MinOccurs causes crash for owslib. This is because owslib will try to parse MinOccurs as long as its set even though its value is an empty string. To fix this, we default MinOccurs to 0 instead of an empty string.