### PR TITLE
made wcs tile size configurable

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -501,8 +501,8 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 			styleLayer = &conf.Layers[idx].Styles[styleIdx]
 		}
 
-		maxXTileSize := 1024
-		maxYTileSize := 1024
+		maxXTileSize := conf.Layers[idx].WcsMaxTileWidth
+		maxYTileSize := conf.Layers[idx].WcsMaxTileHeight
 		checkpointThreshold := 300
 		minTilesPerWorker := 5
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -119,6 +119,8 @@ type Layer struct {
 	WmsMaxHeight             int      `json:"wms_max_height"`
 	WcsMaxWidth              int      `json:"wcs_max_width"`
 	WcsMaxHeight             int      `json:"wcs_max_height"`
+	WcsMaxTileWidth          int      `json:"wcs_max_tile_width"`
+	WcsMaxTileHeight         int      `json:"wcs_max_tile_height"`
 	FeatureInfoMaxDataLinks  int      `json:"feature_info_max_data_links"`
 	FeatureInfoDataLinkUrl   string   `json:"feature_info_data_link_url"`
 	FeatureInfoBands         []string `json:"feature_info_bands"`
@@ -539,6 +541,8 @@ const DefaultWmsMaxWidth = 512
 const DefaultWmsMaxHeight = 512
 const DefaultWcsMaxWidth = 50000
 const DefaultWcsMaxHeight = 30000
+const DefaultWcsMaxTileWidth = 1024
+const DefaultWcsMaxTileHeight = 1024
 
 const DefaultLegendWidth = 160
 const DefaultLegendHeight = 320
@@ -882,6 +886,14 @@ func (config *Config) LoadConfigFile(configFile string, verbose bool) error {
 
 		if config.Layers[i].WcsMaxHeight <= 0 {
 			config.Layers[i].WcsMaxHeight = DefaultWcsMaxHeight
+		}
+
+		if config.Layers[i].WcsMaxTileWidth <= 0 {
+			config.Layers[i].WcsMaxTileWidth = DefaultWcsMaxTileWidth
+		}
+
+		if config.Layers[i].WcsMaxTileHeight <= 0 {
+			config.Layers[i].WcsMaxTileHeight = DefaultWcsMaxTileHeight
 		}
 	}
 


### PR DESCRIPTION
The memory consumption and performance of WCS comes from a trade-off between size of the splitted tiles (e.g. 1024x1024) and the number of underlying data files associated with the bounding box. the complexity is that there is no magic formulae to determine the size of the splitted tiles including not splitting at all. In the extreme case, let's say there is only one data file for the bounding box (this is possible for climate datasets), then we can afford processing the large-sized tile at once and will be certainly faster than splitting it. In contrast, if we have a lot of files, there is virtually no way we can process those files for big tile size without overwhelming the grpc backend. In this case, splitting it is a sensible way to do.  Thus the splitting size including no splitting at all should be in theory auto-tuned based on some statistics of the grpc IO performance and the problem size. For the time being, we made the tile size configurable where the user can manually tweak for their needs.