### PR TITLE
made data unavailable legend image transparent by default

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -307,14 +307,13 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 				}
 				w.Write(out)
 			} else {
-				emptyTile := &utils.ByteRaster{Height: *params.Height, Width: *params.Width}
-				out, err := utils.EncodePNG([]*utils.ByteRaster{emptyTile}, nil)
+				out, err := utils.GetEmptyTile("", *params.Height, *params.Width)
 				if err != nil {
-					Info.Printf("Error in the utils.EncodePNG: %v\n", err)
+					Info.Printf("Error in the utils.GetEmptyTile(): %v\n", err)
 					http.Error(w, err.Error(), 500)
-					return
+				} else {
+					w.Write(out)
 				}
-				w.Write(out)
 			}
 
 			return
@@ -339,9 +338,9 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			}
 
 			if norm[0].Width == 0 || norm[0].Height == 0 {
-				out, err := utils.GetEmptyTile(utils.DataDir+"/data_unavailable.png", *params.Height, *params.Width)
+				out, err := utils.GetEmptyTile(conf.Layers[idx].NoDataLegendPath, *params.Height, *params.Width)
 				if err != nil {
-					Info.Printf("Error in the utils.GetEmptyTile(data_unavailable.png): %v\n", err)
+					Info.Printf("Error in the utils.GetEmptyTile(): %v\n", err)
 					http.Error(w, err.Error(), 500)
 				} else {
 					w.Write(out)

--- a/utils/config.go
+++ b/utils/config.go
@@ -125,6 +125,7 @@ type Layer struct {
 	FeatureInfoDataLinkUrl   string   `json:"feature_info_data_link_url"`
 	FeatureInfoBands         []string `json:"feature_info_bands"`
 	FeatureInfoExpressions   *BandExpressions
+	NoDataLegendPath         string `json:"nodata_legend_path"`
 }
 
 // Process contains all the details that a WPS needs

--- a/utils/empty_tile.go
+++ b/utils/empty_tile.go
@@ -14,27 +14,29 @@ const tSize = 256
 func GetEmptyTile(imageFilename string, height, width int) ([]byte, error) {
 	canvas := image.NewNRGBA(image.Rect(0, 0, width, height))
 
-	infile, err := os.Open(imageFilename)
-	if err != nil {
-		return nil, err
-	}
-	defer infile.Close()
+	if len(imageFilename) > 0 {
+		infile, err := os.Open(imageFilename)
+		if err != nil {
+			return nil, err
+		}
+		defer infile.Close()
 
-	// Decode will figure out what type of image is in the file on its own.
-	// We just have to be sure all the image packages we want are imported.
-	tile, _, err := image.Decode(infile)
-	if err != nil {
-		return nil, err
-	}
+		// Decode will figure out what type of image is in the file on its own.
+		// We just have to be sure all the image packages we want are imported.
+		tile, _, err := image.Decode(infile)
+		if err != nil {
+			return nil, err
+		}
 
-	for x := 0; x < width; x += tSize {
-		for y := 0; y < height; y += tSize {
-			draw.Draw(canvas, image.Rect(x, y, x+tSize, y+tSize), tile, image.ZP, draw.Src)
+		for x := 0; x < width; x += tSize {
+			for y := 0; y < height; y += tSize {
+				draw.Draw(canvas, image.Rect(x, y, x+tSize, y+tSize), tile, image.ZP, draw.Src)
+			}
 		}
 	}
 
 	buf := new(bytes.Buffer)
-	err = png.Encode(buf, canvas)
+	err := png.Encode(buf, canvas)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
More often than not, users overlay layers from other data sources on top of the layers served by GSKY to create a synthetic WMS layer for analysis. Apparently GSKY returns a "data unavailable" image for the region with missing data. This gives poor visual experience for the overlaid layers. Thus it makes more sense if we return a transparent image for missing data in this scenario. Having said that, we should still maintain the functionality to return the "data unavailable" image via a configuration entry when the user needs to indicate the region with missing data.