### PR TITLE
guard against empty norm array

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -337,7 +337,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 				return
 			}
 
-			if norm[0].Width == 0 || norm[0].Height == 0 {
+			if len(norm) == 0 || norm[0].Width == 0 || norm[0].Height == 0 {
 				out, err := utils.GetEmptyTile(conf.Layers[idx].NoDataLegendPath, *params.Height, *params.Width)
 				if err != nil {
 					Info.Printf("Error in the utils.GetEmptyTile(): %v\n", err)


### PR DESCRIPTION
It's possible that the norm array from https://github.com/nci/gsky/blob/v1.1/ows.go#L317 is empty. For example here: https://github.com/nci/gsky/blob/v1.1/processor/tile_merger.go#L342. If the gRPC context is cancelled for the first input raster, and we return. At this moment, the output channel is empty. Thus tp.Process() will be empty. So we have a race. To fix this, we just have to guard against norm array.