### PR TITLE
manually added namespace for chirps2.0 dataset

### DIFF
--- a/crawl/extractor/ruleset.go
+++ b/crawl/extractor/ruleset.go
@@ -112,10 +112,10 @@ var CollectionRuleSets = []RuleSet{
 	},
 	RuleSet{
 		"chirps2.0",
-		NSDataset,
+		NSPath,
 		SRSWGS84,
 		Proj4WGS84,
-		`^chirps-v2.0.(?P<year>\d\d\d\d).dekads.nc$`,
+		`^(?P<namespace>chirps)-v2.0.(?P<year>\d\d\d\d).dekads.nc$`,
 	},
 	RuleSet{
 		"era-interim",


### PR DESCRIPTION
Manually added namespace for the CHIRPS2.0 dataset. Originally CHIRPS2.0 doesn't have a namespace but this is no longer compatible with band maths.