### PR TITLE
fixed single style issue

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -517,9 +517,14 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 			http.Error(w, fmt.Sprintf("Malformed WCS GetCoverage request: %v", err), 400)
 			return
 		} else if styleIdx < 0 {
-			Error.Printf("WCS style not specified")
-			http.Error(w, "WCS style not specified", 400)
-			return
+			styleCount := len(conf.Layers[idx].Styles)
+			if styleCount > 1 {
+				Error.Printf("WCS style not specified")
+				http.Error(w, "WCS style not specified", 400)
+				return
+			} else if styleCount == 1 {
+				styleIdx = 0
+			}
 		}
 
 		styleLayer := &conf.Layers[idx]


### PR DESCRIPTION
Apparently GSKY returns 400 bad request if the style parameter is not set in the WCS request or not found in the configured style list. This is, however, too restrictive if the layer has no styles or a single style. In the case of no style or single style, we should default to the layer itself or the single style to make best efforts to return WCS results to the user.