### PR TITLE
removed unecessary projection to epsg:4326

### DIFF
--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -377,15 +377,10 @@ create or replace function mas_intersects(
       dp_tol := -1.0;
     end if;
 
-    -- supplied WKT in wgs84
     if ST_NPoints(in_geom) > 100 and identity_tol >= 0 and dp_tol >= 0 then
-      mask := ST_SplitDatelineWGS84(ST_Simplify(ST_RemoveRepeatedPoints(
-        ST_Transform(in_geom, 4326), identity_tol), dp_tol)
-      );
+      mask := ST_Simplify(ST_RemoveRepeatedPoints(in_geom, identity_tol), dp_tol);
     else
-      mask := ST_SplitDatelineWGS84(
-        ST_Transform(in_geom, 4326)
-      );
+      mask := in_geom;
     end if;
 
     if mask is null then


### PR DESCRIPTION
Previously the `mas_intersects()` function tries to project the requested bbox into EPSG:4326 before performing the polygon intersection. This approach is problematic because many coordinate systems cannot be perfectly projected into 4326. The reason for the projection failure is due to the fact that 4326 has mathematical issues in handling north and south poles. In fact, it is unnecessary to project the requested polygon to 4326 before the intersection since `mas_intersect_polygons()` always projects the requested polygon into the coordinate system of the dataset before intersection. (i.e. https://github.com/edisonguo/gsky-1/blob/mas_intersects_fix/mas/api/mas.sql#L294)

An example of the failure and the fixed can be illustrated in the following screenshots. The top is the original solution with 4326 projection while the bottom is the fixed solution without the 4326 projection. The dataset is Geoglam total cover.

With EPSG:4326 projection (buggy):
![world_total_cover_buggy](https://user-images.githubusercontent.com/4906167/52824208-e05b6c80-310b-11e9-8cbf-d4c48b66e12c.png)

Without EPSG:4326 projection (fixed):
![world_total_cover_fixed](https://user-images.githubusercontent.com/4906167/52824218-e8b3a780-310b-11e9-94f0-8b5b0a4fd2e8.png)

