### PR TITLE
fixed self-intersecting polygon issue

### DIFF
--- a/worker/gdalprocess/drill.go
+++ b/worker/gdalprocess/drill.go
@@ -248,7 +248,7 @@ func envelopePolygon(hDS C.GDALDatasetH) C.OGRGeometryH {
 }
 
 func getDrillFileDescriptor(ds C.GDALDatasetH, g C.OGRGeometryH) DrillFileDescriptor {
-	gCopy := C.OGR_G_Clone(g)
+	gCopy := C.OGR_G_Buffer(g, C.double(0.0), C.int(30))
 
 	if C.GoString(C.GDALGetProjectionRef(ds)) != "" {
 		desSRS := C.OSRNewSpatialReference(C.GDALGetProjectionRef(ds))


### PR DESCRIPTION
If a large polygon contains a small polygon inside of it (say a polygon that bounds a large region while there is another polygon that bounds a small lake inside of this region), `OGR_G_Intersects()` gives error complaining that topology exception due to self-intersecting polygon, which in fact it is not. To work around this problem, we will have to clean up the polygon before calling `OGR_G_Intersects()`. In words, we call `OGR_G_Buffer(original_polygon, 0.0)` to remove vertices whose distances are almost zero (aka. self-intersecting).