### PR TITLE
initial implementation of blended services

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -306,33 +306,25 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			reqRes = yRes
 		}
 
-		if conf.Layers[idx].ZoomLimit != 0.0 && reqRes > conf.Layers[idx].ZoomLimit {
-			indexer := proc.NewTileIndexer(ctx, conf.ServiceConfig.MASAddress, errChan)
-			go func() {
-				geoReq.Mask = nil
-				geoReq.QueryLimit = 1
-				indexer.In <- geoReq
-				close(indexer.In)
-			}()
+		timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Duration(conf.Layers[idx].WmsTimeout)*time.Second)
+		defer timeoutCancel()
 
-			go indexer.Run(*verbose)
+		tp := proc.InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, conf.ServiceConfig.WorkerNodes, conf.Layers[idx].MaxGrpcRecvMsgSize, conf.Layers[idx].WmsPolygonShardConcLimit, conf.ServiceConfig.MaxGrpcBufferSize, errChan)
+		tp.CurrentLayer = styleLayer
+		tp.DataSources = configMap
+
+		if conf.Layers[idx].ZoomLimit != 0.0 && reqRes > conf.Layers[idx].ZoomLimit {
+			geoReq.Mask = nil
+			geoReq.QueryLimit = 1
 
 			hasData := false
-			for geo := range indexer.Out {
-				select {
-				case <-errChan:
-					break
-				case <-ctx.Done():
-					break
-				default:
+			indexerOut, err := tp.GetFileList(geoReq, *verbose)
+			if err == nil {
+				for _, geo := range indexerOut {
 					if geo.NameSpace != utils.EmptyTileNS {
 						hasData = true
 						break
 					}
-				}
-
-				if hasData {
-					break
 				}
 			}
 
@@ -357,12 +349,6 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			return
 		}
 
-		timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Duration(conf.Layers[idx].WmsTimeout)*time.Second)
-		defer timeoutCancel()
-
-		tp := proc.InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, conf.ServiceConfig.WorkerNodes, conf.Layers[idx].MaxGrpcRecvMsgSize, conf.Layers[idx].WmsPolygonShardConcLimit, conf.ServiceConfig.MaxGrpcBufferSize, errChan)
-		tp.CurrentLayer = styleLayer
-		tp.DataSources = configMap
 		select {
 		case res := <-tp.Process(geoReq, *verbose):
 			scaleParams := utils.ScaleParams{Offset: geoReq.ScaleParams.Offset,

--- a/processor/feature_info.go
+++ b/processor/feature_info.go
@@ -9,20 +9,27 @@ import (
 	"time"
 )
 
-func GetFeatureInfo(ctx context.Context, params utils.WMSParams, conf *utils.Config, verbose bool) (string, error) {
-	raster, namespaces, dsFiles, err := getRaster(ctx, params, conf, verbose)
+type featureInfo struct {
+	Raster     []utils.Raster
+	Namespaces []string
+	DsFiles    []string
+	DsDates    []string
+}
+
+func GetFeatureInfo(ctx context.Context, params utils.WMSParams, conf *utils.Config, configMap map[string]*utils.Config, verbose bool) (string, error) {
+	ftInfo, err := getRaster(ctx, params, conf, configMap, verbose)
 	if err != nil {
 		return "", err
 	}
 
 	out := `"bands": {`
 
-	if len(raster) == 1 {
-		if rs, ok := raster[0].(*utils.ByteRaster); ok {
+	if len(ftInfo.Raster) == 1 {
+		if rs, ok := ftInfo.Raster[0].(*utils.ByteRaster); ok {
 			if rs.NameSpace == "ZoomOut" {
-				for i, ns := range namespaces {
+				for i, ns := range ftInfo.Namespaces {
 					out += fmt.Sprintf(`"%s":"zoom in to view"`, ns)
-					if i < len(namespaces)-1 {
+					if i < len(ftInfo.Namespaces)-1 {
 						out += ","
 					}
 				}
@@ -36,7 +43,7 @@ func GetFeatureInfo(ctx context.Context, params utils.WMSParams, conf *utils.Con
 		}
 	}
 
-	width, height, _, err := utils.ValidateRasterSlice(raster)
+	width, height, _, err := utils.ValidateRasterSlice(ftInfo.Raster)
 	if err != nil {
 		return "", err
 	}
@@ -49,8 +56,8 @@ func GetFeatureInfo(ctx context.Context, params utils.WMSParams, conf *utils.Con
 		return "", fmt.Errorf("x or y out of bound")
 	}
 
-	for i, ns := range namespaces {
-		r := raster[i]
+	for i, ns := range ftInfo.Namespaces {
+		r := ftInfo.Raster[i]
 		var valueStr string
 
 		switch t := r.(type) {
@@ -92,12 +99,23 @@ func GetFeatureInfo(ctx context.Context, params utils.WMSParams, conf *utils.Con
 		}
 
 		out += fmt.Sprintf(`"%s": %s`, ns, valueStr)
-		if i < len(namespaces)-1 {
+		if i < len(ftInfo.Namespaces)-1 {
 			out += ","
 		}
 	}
 
-	if len(dsFiles) > 0 {
+	if len(ftInfo.DsDates) > 0 {
+		out += `, "data_available_for_dates":[`
+		for i, ts := range ftInfo.DsDates {
+			out += fmt.Sprintf(`"%s"`, ts)
+			if i < len(ftInfo.DsDates)-1 {
+				out += ","
+			}
+		}
+		out += `]`
+	}
+
+	if len(ftInfo.DsFiles) > 0 {
 		prefix := ""
 		idx, _ := utils.GetLayerIndex(params, conf)
 		if len(conf.Layers[idx].FeatureInfoDataLinkUrl) > 0 {
@@ -107,33 +125,34 @@ func GetFeatureInfo(ctx context.Context, params utils.WMSParams, conf *utils.Con
 			}
 		}
 		out += `, "data_links":[`
-		for i, file := range dsFiles {
+		for i, file := range ftInfo.DsFiles {
 
 			out += fmt.Sprintf(`"%s%s"`, prefix, file)
-			if i < len(dsFiles)-1 {
+			if i < len(ftInfo.DsFiles)-1 {
 				out += ","
 			}
 		}
-
 		out += `]`
 	}
 	out += `}`
 	return out, nil
 }
 
-func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, verbose bool) ([]utils.Raster, []string, []string, error) {
+func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, configMap map[string]*utils.Config, verbose bool) (*featureInfo, error) {
+	ftInfo := &featureInfo{}
+
 	idx, err := utils.GetLayerIndex(params, conf)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Malformed WMS GetFeatureInfo request: %v", err)
+		return nil, fmt.Errorf("Malformed WMS GetFeatureInfo request: %v", err)
 	}
 	if params.Time == nil {
-		return nil, nil, nil, fmt.Errorf("Request should contain a valid time.")
+		return nil, fmt.Errorf("Request should contain a valid time.")
 	}
 	if params.CRS == nil {
-		return nil, nil, nil, fmt.Errorf("Request should contain a valid ISO 'crs/srs' parameter.")
+		return nil, fmt.Errorf("Request should contain a valid ISO 'crs/srs' parameter.")
 	}
 	if len(params.BBox) != 4 {
-		return nil, nil, nil, fmt.Errorf("Request should contain a valid 'bbox' parameter.")
+		return nil, fmt.Errorf("Request should contain a valid 'bbox' parameter.")
 	}
 
 	xRes := (params.BBox[2] - params.BBox[0]) / float64(*params.Width)
@@ -145,7 +164,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 
 	styleIdx, err := utils.GetLayerStyleIndex(params, conf, idx)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, err
 	}
 
 	styleLayer := &conf.Layers[idx]
@@ -167,18 +186,20 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	}
 
 	if conf.Layers[idx].ZoomLimit != 0.0 && reqRes > conf.Layers[idx].ZoomLimit {
-		return []utils.Raster{&utils.ByteRaster{NameSpace: "ZoomOut"}}, bandExpr.ExprNames, nil, nil
+		ftInfo.Namespaces = bandExpr.ExprNames
+		ftInfo.Raster = []utils.Raster{&utils.ByteRaster{NameSpace: "ZoomOut"}}
+		return ftInfo, nil
 	}
 
 	if params.Height == nil || params.Width == nil {
-		return nil, nil, nil, fmt.Errorf("Request should contain valid 'width' and 'height' parameters.")
+		return nil, fmt.Errorf("Request should contain valid 'width' and 'height' parameters.")
 	}
 	if *params.Height > conf.Layers[idx].WmsMaxHeight || *params.Width > conf.Layers[idx].WmsMaxWidth {
-		return nil, nil, nil, fmt.Errorf("Requested width/height is too large, max width:%d, height:%d", conf.Layers[idx].WmsMaxWidth, conf.Layers[idx].WmsMaxHeight)
+		return nil, fmt.Errorf("Requested width/height is too large, max width:%d, height:%d", conf.Layers[idx].WmsMaxWidth, conf.Layers[idx].WmsMaxHeight)
 	}
 
 	if params.X == nil || params.Y == nil {
-		return nil, nil, nil, fmt.Errorf("Request should contain valid 'x' and 'y' parameters.")
+		return nil, fmt.Errorf("Request should contain valid 'x' and 'y' parameters.")
 	}
 	if strings.ToUpper(*params.CRS) == "EPSG:4326" && *params.Version == "1.3.0" {
 		params.BBox = []float64{params.BBox[1], params.BBox[0], params.BBox[3], params.BBox[2]}
@@ -195,7 +216,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	}
 
 	if len(conf.Layers[idx].DataSource) == 0 {
-		return nil, nil, nil, fmt.Errorf("Invalid data source")
+		return nil, fmt.Errorf("Invalid data source")
 	}
 
 	// We construct a 2x2 image corresponding to an infinitesimal bounding box
@@ -253,37 +274,51 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 
 	var outRaster []utils.Raster
 	tp := InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, conf.ServiceConfig.WorkerNodes, conf.Layers[idx].MaxGrpcRecvMsgSize, conf.Layers[idx].WmsPolygonShardConcLimit, conf.ServiceConfig.MaxGrpcBufferSize, errChan)
+	tp.CurrentLayer = styleLayer
+	tp.DataSources = configMap
+
 	select {
 	case res := <-tp.Process(geoReq, verbose):
 		outRaster = res
 	case err := <-errChan:
-		return nil, nil, nil, err
+		return nil, err
 	case <-ctx.Done():
-		return nil, nil, nil, ctx.Err()
+		return nil, ctx.Err()
 	}
 
-	if conf.Layers[idx].FeatureInfoMaxDataLinks < 1 {
-		return outRaster, bandExpr.ExprNames, nil, nil
+	ftInfo.Raster = outRaster
+	ftInfo.Namespaces = bandExpr.ExprNames
+	if conf.Layers[idx].FeatureInfoMaxAvailableDates == 0 && conf.Layers[idx].FeatureInfoMaxDataLinks == 0 {
+		return ftInfo, nil
 	}
 
-	indexer := NewTileIndexer(ctx, conf.ServiceConfig.MASAddress, errChan)
-	go func() {
-		geoReq.Mask = nil
-		indexer.In <- geoReq
-		close(indexer.In)
-	}()
+	if conf.Layers[idx].FeatureInfoMaxAvailableDates != 0 {
+		geoReq.StartTime = &time.Time{}
+		//		geoReq.EndTime = nil
+	}
 
-	go indexer.Run(verbose)
+	tp = InitTilePipeline(ctx, conf.ServiceConfig.MASAddress, conf.ServiceConfig.WorkerNodes, conf.Layers[idx].MaxGrpcRecvMsgSize, conf.Layers[idx].WmsPolygonShardConcLimit, conf.ServiceConfig.MaxGrpcBufferSize, errChan)
+	tp.CurrentLayer = styleLayer
+	tp.DataSources = configMap
+
+	indexerOut := tp.GetFileList(geoReq, verbose)
 
 	var pixelFiles []*GeoTileGranule
-	for geo := range indexer.Out {
+	timestampLookup := make(map[time.Time]bool)
+	for geo := range indexerOut {
 		select {
 		case err := <-errChan:
-			return nil, nil, nil, err
+			return nil, err
 		case <-ctx.Done():
-			return nil, nil, nil, ctx.Err()
+			return nil, ctx.Err()
 		default:
 			if geo.NameSpace == utils.EmptyTileNS {
+				continue
+			}
+
+			tm := time.Unix(int64(geo.TimeStamp), 0)
+			normalizedTm := time.Date(tm.Year(), tm.Month(), tm.Day(), 0, 0, 0, 0, time.UTC)
+			if _, found := timestampLookup[normalizedTm]; found {
 				continue
 			}
 
@@ -291,9 +326,29 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 		}
 	}
 
-	sort.Slice(pixelFiles, func(i, j int) bool { return pixelFiles[i].TimeStamp <= pixelFiles[j].TimeStamp })
+	sort.Slice(pixelFiles, func(i, j int) bool { return pixelFiles[i].TimeStamp >= pixelFiles[j].TimeStamp })
+
+	var topDsDates []string
+	if conf.Layers[idx].FeatureInfoMaxAvailableDates != 0 {
+		for i, ds := range pixelFiles {
+			tm := time.Unix(int64(ds.TimeStamp), 0)
+			normalizedTm := time.Date(tm.Year(), tm.Month(), tm.Day(), 0, 0, 0, 0, time.UTC).Format(utils.ISOFormat)
+			topDsDates = append(topDsDates, normalizedTm)
+
+			if conf.Layers[idx].FeatureInfoMaxAvailableDates > 0 && i+1 >= conf.Layers[idx].FeatureInfoMaxAvailableDates {
+				break
+			}
+		}
+		ftInfo.DsDates = topDsDates
+	}
+
+	fmt.Printf("xxxxxxxxxxx %v, %v, %v", len(pixelFiles), conf.Layers[idx].FeatureInfoMaxAvailableDates, topDsDates)
 
 	var topDsFiles []string
+	if conf.Layers[idx].FeatureInfoMaxDataLinks == 0 {
+		return ftInfo, nil
+	}
+
 	fileDedup := make(map[string]bool)
 	for i, ds := range pixelFiles {
 		dsFile := ds.RawPath
@@ -315,11 +370,11 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 			dsFile = dsFile[len(styleLayer.DataSource)+offset:]
 			topDsFiles = append(topDsFiles, dsFile)
 
-			if i+1 >= conf.Layers[idx].FeatureInfoMaxDataLinks {
+			if conf.Layers[idx].FeatureInfoMaxDataLinks > 0 && i+1 >= conf.Layers[idx].FeatureInfoMaxDataLinks {
 				break
 			}
 		}
 	}
-
-	return outRaster, bandExpr.ExprNames, topDsFiles, nil
+	ftInfo.DsFiles = topDsFiles
+	return ftInfo, nil
 }

--- a/processor/tile_merger.go
+++ b/processor/tile_merger.go
@@ -428,9 +428,7 @@ func (enc *RasterMerger) Run(polyLimiter *ConcLimiter, bandExpr *utils.BandExpre
 			canvasMap = tmpMap
 		}
 
-		if polyLimiter != nil {
-			polyLimiter.Decrease()
-		}
+		polyLimiter.Decrease()
 	}
 
 	select {
@@ -440,9 +438,13 @@ func (enc *RasterMerger) Run(polyLimiter *ConcLimiter, bandExpr *utils.BandExpre
 	}
 
 	var nameSpaces []string
-	for _, canvas := range canvasMap {
-		nameSpaces = canvas.ConfigPayLoad.NameSpaces
-		break
+	if _, found := canvasMap[utils.EmptyTileNS]; found {
+		nameSpaces = append(nameSpaces, utils.EmptyTileNS)
+	} else {
+		for _, canvas := range canvasMap {
+			nameSpaces = canvas.ConfigPayLoad.NameSpaces
+			break
+		}
 	}
 
 	if len(nameSpaces) == 0 {

--- a/processor/tile_merger.go
+++ b/processor/tile_merger.go
@@ -44,7 +44,6 @@ func MergeMaskedRaster(r *FlexRaster, canvasMap map[string]*FlexRaster, mask []b
 		header := *(*reflect.SliceHeader)(unsafe.Pointer(&r.Data))
 		data := *(*[]uint8)(unsafe.Pointer(&header))
 		nodata := uint8(r.NoData)
-
 		if r.TimeStamp < canvasMap[r.NameSpace].TimeStamp {
 			iSrc := 0
 			for ir := 0; ir < r.DataHeight; ir++ {
@@ -429,7 +428,9 @@ func (enc *RasterMerger) Run(polyLimiter *ConcLimiter, bandExpr *utils.BandExpre
 			canvasMap = tmpMap
 		}
 
-		polyLimiter.Decrease()
+		if polyLimiter != nil {
+			polyLimiter.Decrease()
+		}
 	}
 
 	select {

--- a/processor/tile_pipeline.go
+++ b/processor/tile_pipeline.go
@@ -2,7 +2,12 @@ package processor
 
 import (
 	"context"
+	"fmt"
 	"github.com/nci/gsky/utils"
+	"log"
+	"reflect"
+	"time"
+	"unsafe"
 )
 
 type TilePipeline struct {
@@ -13,6 +18,15 @@ type TilePipeline struct {
 	PolygonShardConcLimit int
 	MASAddress            string
 	MaxGrpcBufferSize     int
+	CurrentLayer          *utils.Layer
+	DataSources           map[string]*utils.Config
+}
+
+type GeoReqContext struct {
+	Service    *utils.ServiceConfig
+	Layer      *utils.Layer
+	StyleLayer *utils.Layer
+	GeoReq     *GeoTileRequest
 }
 
 func InitTilePipeline(ctx context.Context, masAddr string, rpcAddr []string, maxGrpcRecvMsgSize int, polygonShardConcLimit int, maxGrpcBufferSize int, errChan chan error) *TilePipeline {
@@ -28,24 +42,217 @@ func InitTilePipeline(ctx context.Context, masAddr string, rpcAddr []string, max
 }
 
 func (dp *TilePipeline) Process(geoReq *GeoTileRequest, verbose bool) chan []utils.Raster {
-	grpcTiler := NewRasterGRPC(dp.Context, dp.RPCAddress, dp.MaxGrpcRecvMsgSize, dp.PolygonShardConcLimit, dp.MaxGrpcBufferSize, dp.Error)
+	if dp.CurrentLayer != nil && len(dp.CurrentLayer.InputLayers) > 0 {
+		return dp.processDeps(geoReq, verbose)
+	} else {
+		grpcTiler := NewRasterGRPC(dp.Context, dp.RPCAddress, dp.MaxGrpcRecvMsgSize, dp.PolygonShardConcLimit, dp.MaxGrpcBufferSize, dp.Error)
 
-	i := NewTileIndexer(dp.Context, dp.MASAddress, dp.Error)
-	go func() {
-		i.In <- geoReq
-		close(i.In)
-	}()
+		i := NewTileIndexer(dp.Context, dp.MASAddress, dp.Error)
+		go func() {
+			i.In <- geoReq
+			close(i.In)
+		}()
 
-	m := NewRasterMerger(dp.Context, dp.Error)
+		m := NewRasterMerger(dp.Context, dp.Error)
 
-	grpcTiler.In = i.Out
-	m.In = grpcTiler.Out
+		grpcTiler.In = i.Out
+		m.In = grpcTiler.Out
 
-	polyLimiter := NewConcLimiter(dp.PolygonShardConcLimit)
-	go i.Run(verbose)
-	go grpcTiler.Run(polyLimiter, geoReq.BandExpr.VarList, verbose)
-	go m.Run(polyLimiter, geoReq.BandExpr, verbose)
+		polyLimiter := NewConcLimiter(dp.PolygonShardConcLimit)
+		go i.Run(verbose)
+		go grpcTiler.Run(polyLimiter, geoReq.BandExpr.VarList, verbose)
+		go m.Run(polyLimiter, geoReq.BandExpr, verbose)
+
+		return m.Out
+	}
+
+}
+
+func (dp *TilePipeline) processDeps(geoReq *GeoTileRequest, verbose bool) chan []utils.Raster {
+	errChan := make(chan error, 100)
+
+	m := NewRasterMerger(dp.Context, errChan)
+	defer close(m.In)
+	go m.Run(nil, geoReq.BandExpr, verbose)
+
+	depLayers, err := dp.findDepLayers()
+	if err != nil {
+		dp.Error <- err
+		return m.Out
+	}
+	dp.prepareInputGeoRequests(geoReq, depLayers)
+
+	var timestamp time.Time
+	if geoReq.StartTime != nil {
+		timestamp = *geoReq.StartTime
+	} else {
+		timestamp = time.Now().UTC()
+	}
+
+	var rasters []*FlexRaster
+	for idx, reqCtx := range depLayers {
+		tp := InitTilePipeline(dp.Context, reqCtx.Service.MASAddress, reqCtx.Service.WorkerNodes, reqCtx.Layer.MaxGrpcRecvMsgSize, reqCtx.Layer.WmsPolygonShardConcLimit, reqCtx.Service.MaxGrpcBufferSize, errChan)
+
+		req := reqCtx.GeoReq
+		select {
+		case res := <-tp.Process(req, verbose):
+			timeDelta := time.Second * time.Duration(-idx)
+			hasScaleParams := !(req.ScaleParams.Offset == 0 && req.ScaleParams.Scale == 0 && req.ScaleParams.Clip == 0)
+			if hasScaleParams {
+				scaleParams := utils.ScaleParams{Offset: req.ScaleParams.Offset,
+					Scale: req.ScaleParams.Scale,
+					Clip:  req.ScaleParams.Clip,
+				}
+
+				norm, err := utils.Scale(res, scaleParams)
+				if err != nil {
+					if verbose {
+						log.Printf("fusion pipeline(%d of %d) utils.Scale error: %v", idx+1, len(depLayers), err)
+					}
+					dp.Error <- err
+					return m.Out
+				}
+
+				if len(norm) == 0 || norm[0].Width == 0 || norm[0].Height == 0 || norm[0].NameSpace == "EmptyTile" {
+					if verbose {
+						log.Printf("fusion pipeline(%d of %d): empty tile", idx+1, len(depLayers))
+					}
+					break
+				}
+
+				for j := range norm {
+					norm[j].NoData = 0xFF
+					flex := getFlexRaster(j, timestamp.Add(timeDelta), geoReq, norm[j])
+					rasters = append(rasters, flex)
+				}
+			} else {
+				for j := range res {
+					flex := getFlexRaster(j, timestamp.Add(timeDelta), geoReq, res[j])
+					rasters = append(rasters, flex)
+				}
+			}
+
+		case err := <-errChan:
+			log.Printf("Error in the fusion pipeline(%d of %d): %v", idx+1, len(depLayers), err)
+			dp.Error <- err
+			return m.Out
+		case <-tp.Context.Done():
+			log.Printf("Context cancelled in fusion pipeline(%d of %d)", idx+1, len(depLayers))
+			return m.Out
+		}
+	}
+	if len(rasters) == 0 {
+		m.Out <- []utils.Raster{&utils.ByteRaster{Data: make([]uint8, geoReq.Height*geoReq.Width), NoData: 0, Height: geoReq.Height, Width: geoReq.Width, NameSpace: utils.EmptyTileNS}}
+	} else {
+		m.In <- rasters
+	}
 
 	return m.Out
+}
 
+func (dp *TilePipeline) findDepLayers() ([]*GeoReqContext, error) {
+	var layers []*GeoReqContext
+	for _, refLayer := range dp.CurrentLayer.InputLayers {
+		config, found := dp.DataSources[refLayer.NameSpace]
+		if !found {
+			return layers, fmt.Errorf("namespace %s not found referenced by %s", refLayer.NameSpace, refLayer.Name)
+		}
+
+		params := utils.WMSParams{Layers: []string{refLayer.Name}}
+
+		layerIdx, err := utils.GetLayerIndex(params, config)
+		if err != nil {
+			return layers, err
+		}
+
+		styleLayer := &config.Layers[layerIdx]
+		layer := styleLayer
+		if len(refLayer.Styles) > 0 {
+			params.Styles = []string{refLayer.Styles[0].Name}
+			styleIdx, err := utils.GetLayerStyleIndex(params, config, layerIdx)
+			if err != nil {
+				return layers, err
+			}
+
+			if styleIdx >= 0 {
+				styleLayer = &config.Layers[layerIdx].Styles[styleIdx]
+			}
+
+		} else {
+			if len(styleLayer.Styles) == 1 {
+				styleLayer = &config.Layers[layerIdx].Styles[0]
+			} else if len(styleLayer.Styles) > 0 {
+				return layers, fmt.Errorf("referenced layer %s has multiple styles", refLayer.Name)
+			}
+		}
+		layers = append(layers, &GeoReqContext{Service: &config.ServiceConfig, Layer: layer, StyleLayer: styleLayer})
+	}
+
+	return layers, nil
+}
+
+func (dp *TilePipeline) prepareInputGeoRequests(geoReq *GeoTileRequest, depLayers []*GeoReqContext) {
+	for _, ctx := range depLayers {
+		styleLayer := ctx.StyleLayer
+		ctx.GeoReq = &GeoTileRequest{ConfigPayLoad: ConfigPayLoad{NameSpaces: styleLayer.RGBExpressions.VarList,
+			ScaleParams: ScaleParams{Offset: styleLayer.OffsetValue,
+				Scale: styleLayer.ScaleValue,
+				Clip:  styleLayer.ClipValue,
+			},
+
+			BandExpr:        styleLayer.RGBExpressions,
+			Mask:            styleLayer.Mask,
+			Palette:         styleLayer.Palette,
+			ZoomLimit:       geoReq.ZoomLimit,
+			PolygonSegments: geoReq.PolygonSegments,
+			GrpcConcLimit:   geoReq.GrpcConcLimit,
+			QueryLimit:      geoReq.QueryLimit,
+		},
+			Collection: styleLayer.DataSource,
+			CRS:        geoReq.CRS,
+			BBox:       geoReq.BBox,
+			Height:     geoReq.Height,
+			Width:      geoReq.Width,
+			StartTime:  geoReq.StartTime,
+			EndTime:    geoReq.EndTime,
+		}
+	}
+}
+
+func getFlexRaster(idx int, timestamp time.Time, req *GeoTileRequest, raster utils.Raster) *FlexRaster {
+	namespace := fmt.Sprintf("fuse%d", idx)
+	flex := &FlexRaster{ConfigPayLoad: req.ConfigPayLoad, NameSpace: namespace, TimeStamp: float64(timestamp.Unix()), Polygon: "dummy_polygon", Height: req.Height, Width: req.Width, DataHeight: req.Height, DataWidth: req.Width}
+	switch t := raster.(type) {
+	case *utils.ByteRaster:
+		flex.Type = "Byte"
+		flex.NoData = t.NoData
+		flex.Data = t.Data
+
+	case *utils.Int16Raster:
+		flex.Type = "Int16"
+		flex.NoData = t.NoData
+		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&t.Data))
+		headr.Len *= SizeofInt16
+		headr.Cap *= SizeofInt16
+		flex.Data = *(*[]uint8)(unsafe.Pointer(&headr))
+
+	case *utils.UInt16Raster:
+		flex.Type = "UInt16"
+		flex.NoData = t.NoData
+		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&t.Data))
+		headr.Len *= SizeofUint16
+		headr.Cap *= SizeofUint16
+		flex.Data = *(*[]uint8)(unsafe.Pointer(&headr))
+
+	case *utils.Float32Raster:
+		flex.Type = "Float32"
+		flex.NoData = t.NoData
+		headr := *(*reflect.SliceHeader)(unsafe.Pointer(&t.Data))
+		headr.Len *= SizeofFloat32
+		headr.Cap *= SizeofFloat32
+		flex.Data = *(*[]uint8)(unsafe.Pointer(&headr))
+
+	}
+
+	return flex
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -79,16 +79,17 @@ type LayerAxis struct {
 // to be published and rendered
 type Layer struct {
 	OWSHostname string `json:"ows_hostname"`
-	NameSpace   string
+	NameSpace   string `json:"namespace"`
 	Name        string `json:"name"`
 	Title       string `json:"title"`
 	Abstract    string `json:"abstract"`
 	MetadataURL string `json:"metadata_url"`
 	DataURL     string `json:"data_url"`
 	//CacheLevels  []CacheLevel `json:"cache_levels"`
-	DataSource               string `json:"data_source"`
-	StartISODate             string `json:"start_isodate"`
-	EndISODate               string `json:"end_isodate"`
+	InputLayers              []Layer `json:"input_layers"`
+	DataSource               string  `json:"data_source"`
+	StartISODate             string  `json:"start_isodate"`
+	EndISODate               string  `json:"end_isodate"`
 	EffectiveStartDate       string
 	EffectiveEndDate         string
 	TimestampToken           string

--- a/utils/config.go
+++ b/utils/config.go
@@ -86,58 +86,59 @@ type Layer struct {
 	MetadataURL string `json:"metadata_url"`
 	DataURL     string `json:"data_url"`
 	//CacheLevels  []CacheLevel `json:"cache_levels"`
-	InputLayers              []Layer `json:"input_layers"`
-	DataSource               string  `json:"data_source"`
-	StartISODate             string  `json:"start_isodate"`
-	EndISODate               string  `json:"end_isodate"`
-	EffectiveStartDate       string
-	EffectiveEndDate         string
-	TimestampToken           string
-	StepDays                 int      `json:"step_days"`
-	StepHours                int      `json:"step_hours"`
-	StepMinutes              int      `json:"step_minutes"`
-	Accum                    bool     `json:"accum"`
-	TimeGen                  string   `json:"time_generator"`
-	ResFilter                *int     `json:"resolution_filter"`
-	Dates                    []string `json:"dates"`
-	RGBProducts              []string `json:"rgb_products"`
-	RGBExpressions           *BandExpressions
-	Mask                     *Mask    `json:"mask"`
-	OffsetValue              float64  `json:"offset_value"`
-	ClipValue                float64  `json:"clip_value"`
-	ScaleValue               float64  `json:"scale_value"`
-	Palette                  *Palette `json:"palette"`
-	LegendPath               string   `json:"legend_path"`
-	LegendHeight             int      `json:"legend_height"`
-	LegendWidth              int      `json:"legend_width"`
-	Styles                   []Layer  `json:"styles"`
-	ZoomLimit                float64  `json:"zoom_limit"`
-	MaxGrpcRecvMsgSize       int      `json:"max_grpc_recv_msg_size"`
-	WmsPolygonSegments       int      `json:"wms_polygon_segments"`
-	WcsPolygonSegments       int      `json:"wcs_polygon_segments"`
-	WmsTimeout               int      `json:"wms_timeout"`
-	WcsTimeout               int      `json:"wcs_timeout"`
-	GrpcWmsConcPerNode       int      `json:"grpc_wms_conc_per_node"`
-	GrpcWcsConcPerNode       int      `json:"grpc_wcs_conc_per_node"`
-	WmsPolygonShardConcLimit int      `json:"wms_polygon_shard_conc_limit"`
-	WcsPolygonShardConcLimit int      `json:"wcs_polygon_shard_conc_limit"`
-	BandStrides              int      `json:"band_strides"`
-	WmsMaxWidth              int      `json:"wms_max_width"`
-	WmsMaxHeight             int      `json:"wms_max_height"`
-	WcsMaxWidth              int      `json:"wcs_max_width"`
-	WcsMaxHeight             int      `json:"wcs_max_height"`
-	WcsMaxTileWidth          int      `json:"wcs_max_tile_width"`
-	WcsMaxTileHeight         int      `json:"wcs_max_tile_height"`
-	FeatureInfoMaxDataLinks  int      `json:"feature_info_max_data_links"`
-	FeatureInfoDataLinkUrl   string   `json:"feature_info_data_link_url"`
-	FeatureInfoBands         []string `json:"feature_info_bands"`
-	FeatureInfoExpressions   *BandExpressions
-	NoDataLegendPath         string       `json:"nodata_legend_path"`
-	AxesInfo                 []*LayerAxis `json:"axes"`
-	UserSrcSRS               int          `json:"src_srs"`
-	UserSrcGeoTransform      int          `json:"src_geo_transform"`
-	DefaultGeoBbox           []float64    `json:"default_geo_bbox"`
-	DefaultGeoSize           []int        `json:"default_geo_size"`
+	InputLayers                  []Layer `json:"input_layers"`
+	DataSource                   string  `json:"data_source"`
+	StartISODate                 string  `json:"start_isodate"`
+	EndISODate                   string  `json:"end_isodate"`
+	EffectiveStartDate           string
+	EffectiveEndDate             string
+	TimestampToken               string
+	StepDays                     int      `json:"step_days"`
+	StepHours                    int      `json:"step_hours"`
+	StepMinutes                  int      `json:"step_minutes"`
+	Accum                        bool     `json:"accum"`
+	TimeGen                      string   `json:"time_generator"`
+	ResFilter                    *int     `json:"resolution_filter"`
+	Dates                        []string `json:"dates"`
+	RGBProducts                  []string `json:"rgb_products"`
+	RGBExpressions               *BandExpressions
+	Mask                         *Mask    `json:"mask"`
+	OffsetValue                  float64  `json:"offset_value"`
+	ClipValue                    float64  `json:"clip_value"`
+	ScaleValue                   float64  `json:"scale_value"`
+	Palette                      *Palette `json:"palette"`
+	LegendPath                   string   `json:"legend_path"`
+	LegendHeight                 int      `json:"legend_height"`
+	LegendWidth                  int      `json:"legend_width"`
+	Styles                       []Layer  `json:"styles"`
+	ZoomLimit                    float64  `json:"zoom_limit"`
+	MaxGrpcRecvMsgSize           int      `json:"max_grpc_recv_msg_size"`
+	WmsPolygonSegments           int      `json:"wms_polygon_segments"`
+	WcsPolygonSegments           int      `json:"wcs_polygon_segments"`
+	WmsTimeout                   int      `json:"wms_timeout"`
+	WcsTimeout                   int      `json:"wcs_timeout"`
+	GrpcWmsConcPerNode           int      `json:"grpc_wms_conc_per_node"`
+	GrpcWcsConcPerNode           int      `json:"grpc_wcs_conc_per_node"`
+	WmsPolygonShardConcLimit     int      `json:"wms_polygon_shard_conc_limit"`
+	WcsPolygonShardConcLimit     int      `json:"wcs_polygon_shard_conc_limit"`
+	BandStrides                  int      `json:"band_strides"`
+	WmsMaxWidth                  int      `json:"wms_max_width"`
+	WmsMaxHeight                 int      `json:"wms_max_height"`
+	WcsMaxWidth                  int      `json:"wcs_max_width"`
+	WcsMaxHeight                 int      `json:"wcs_max_height"`
+	WcsMaxTileWidth              int      `json:"wcs_max_tile_width"`
+	WcsMaxTileHeight             int      `json:"wcs_max_tile_height"`
+	FeatureInfoMaxAvailableDates int      `json:"feature_info_max_dates"`
+	FeatureInfoMaxDataLinks      int      `json:"feature_info_max_data_links"`
+	FeatureInfoDataLinkUrl       string   `json:"feature_info_data_link_url"`
+	FeatureInfoBands             []string `json:"feature_info_bands"`
+	FeatureInfoExpressions       *BandExpressions
+	NoDataLegendPath             string       `json:"nodata_legend_path"`
+	AxesInfo                     []*LayerAxis `json:"axes"`
+	UserSrcSRS                   int          `json:"src_srs"`
+	UserSrcGeoTransform          int          `json:"src_geo_transform"`
+	DefaultGeoBbox               []float64    `json:"default_geo_bbox"`
+	DefaultGeoSize               []int        `json:"default_geo_size"`
 }
 
 // Process contains all the details that a WPS needs


### PR DESCRIPTION
This PR contains initial implementation of blended services. The features implemented in this PR as as follows:

* The outputs of arbitrary number of layers can be merged (i.e. blended) in a best-of-last-pixel fashion. Early stopping is also implemented to prune unnecessary IOs. For example, supposed we have 4 layers participating the blending service. If all the pixels become valid after blending the 2nd layer, there is no point to continue blending the 3rd and the 4th layer but early stop the blending process.

* The timestamps of the participating layers form a union ordered set for WMS `GetCapabilities`.

* `getFeatureInfo` can now return the union ordered set of timestamps of all the participating layers associated with the point of interest. This is to facilitate point drill over time.
