### PR TITLE
fixed point drill issue

### DIFF
--- a/worker/gdalprocess/drill.go
+++ b/worker/gdalprocess/drill.go
@@ -249,6 +249,9 @@ func envelopePolygon(hDS C.GDALDatasetH) C.OGRGeometryH {
 
 func getDrillFileDescriptor(ds C.GDALDatasetH, g C.OGRGeometryH) DrillFileDescriptor {
 	gCopy := C.OGR_G_Buffer(g, C.double(0.0), C.int(30))
+	if C.OGR_G_IsEmpty(gCopy) == C.int(1) {
+		gCopy = C.OGR_G_Clone(g)
+	}
 
 	if C.GoString(C.GDALGetProjectionRef(ds)) != "" {
 		desSRS := C.OSRNewSpatialReference(C.GDALGetProjectionRef(ds))


### PR DESCRIPTION
If the input to WPS is a single point, `OGR_G_Buffer` will mistakenly eliminate this single point because the distance of the single point is of course less than any possible threshold. To handle this scenario, we will check if the geometry is empty after `OGR_G_Buffer`. If it is empty, we will simply clone the original geometry.