### PR TITLE
removed duplicated check for blank data source in getFeatureInfo

### DIFF
--- a/processor/feature_info.go
+++ b/processor/feature_info.go
@@ -225,10 +225,6 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 		endTime = &eT
 	}
 
-	if len(conf.Layers[idx].DataSource) == 0 {
-		return nil, fmt.Errorf("Invalid data source")
-	}
-
 	// We construct a 2x2 image corresponding to an infinitesimal bounding box
 	// to approximate a pixel.
 	// We observed several order of magnitude of performance improvement as a


### PR DESCRIPTION
This PR removes the duplicated check for blank `data_source` in `getFeatureInfo`. This check causes trouble for blended layer since blended layer is likely to always configure blank `data_source`.