### PR TITLE
added support for user-defined axes

### DIFF
--- a/crawl/extractor/info.go
+++ b/crawl/extractor/info.go
@@ -183,6 +183,21 @@ func getDataSetInfo(filename string, dsName *C.char, driverName string, approx b
 		ncAxes, err = getNCAxes(datasetName, hSubdataset, ruleSet)
 	}
 
+	for _, axis := range ruleSet.AxesText {
+		foundAxis := false
+		for ia, ax := range ncAxes {
+			if ax.Name == axis.Name {
+				foundAxis = true
+				ncAxes[ia] = axis
+				break
+			}
+		}
+
+		if !foundAxis {
+			ncAxes = append(ncAxes, axis)
+		}
+	}
+
 	var geoLocation *GeoLocInfo
 	if ruleSet.GeoLoc != nil {
 		geoLocTmp, err := getGeoLocation(ruleSet.GeoLoc, filename)

--- a/crawl/extractor/ruleset.go
+++ b/crawl/extractor/ruleset.go
@@ -20,17 +20,18 @@ type GeoLocRule struct {
 }
 
 type RuleSet struct {
-	Collection   string       `json:"collection"`
-	NameSpace    string       `json:"namespace"`
-	SRSText      string       `json:"srs_text"`
-	Proj4Text    string       `json:"proj4_text"`
-	Pattern      string       `json:"pattern"`
-	ComputeStats bool         `json:"compute_stats"`
-	TimeAxis     *DatasetAxis `json:"time_axis"`
-	TimeUnits    string       `json:"time_units"`
-	TimesText    []string     `json:"times_text"`
-	BBox         []float64    `json:"bbox"`
-	GeoLoc       *GeoLocRule  `json:"geo_loc"`
+	Collection   string         `json:"collection"`
+	NameSpace    string         `json:"namespace"`
+	SRSText      string         `json:"srs_text"`
+	Proj4Text    string         `json:"proj4_text"`
+	Pattern      string         `json:"pattern"`
+	ComputeStats bool           `json:"compute_stats"`
+	TimeAxis     *DatasetAxis   `json:"time_axis"`
+	TimeUnits    string         `json:"time_units"`
+	TimesText    []string       `json:"times_text"`
+	BBox         []float64      `json:"bbox"`
+	GeoLoc       *GeoLocRule    `json:"geo_loc"`
+	AxesText     []*DatasetAxis `json:"axes_text,omitempty"`
 }
 
 /***** An example config file for the eReefs dataset


### PR DESCRIPTION
This PR adds support for user-defined axes. This is useful when mapping linearised GDAL bands to axes. For example, some GeoTIff files use band 1, 2, 3 to represent red, green and blue. GSKY, however, requires three distinct variables for RGB. With this PR, we can now map create a pseudo axis (say colour) to map band 1, 2, 3 to the colour axis.