### PR TITLE
added support for rendering wms images in logarithmic scale

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -286,13 +286,19 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			}
 		}
 
+		colourScale := styleLayer.ColourScale
+		if params.ColourScale != nil {
+			colourScale = *params.ColourScale
+		}
+
 		geoReq := &proc.GeoTileRequest{ConfigPayLoad: proc.ConfigPayLoad{NameSpaces: styleLayer.RGBExpressions.VarList,
 			BandExpr: styleLayer.RGBExpressions,
 			Mask:     styleLayer.Mask,
 			Palette:  palette,
 			ScaleParams: proc.ScaleParams{Offset: offset,
-				Scale: scale,
-				Clip:  clip,
+				Scale:       scale,
+				Clip:        clip,
+				ColourScale: colourScale,
 			},
 			ZoomLimit:           conf.Layers[idx].ZoomLimit,
 			PolygonSegments:     conf.Layers[idx].WmsPolygonSegments,
@@ -382,8 +388,9 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 		select {
 		case res := <-tp.Process(geoReq, *verbose):
 			scaleParams := utils.ScaleParams{Offset: geoReq.ScaleParams.Offset,
-				Scale: geoReq.ScaleParams.Scale,
-				Clip:  geoReq.ScaleParams.Clip,
+				Scale:       geoReq.ScaleParams.Scale,
+				Clip:        geoReq.ScaleParams.Clip,
+				ColourScale: geoReq.ScaleParams.ColourScale,
 			}
 
 			norm, err := utils.Scale(res, scaleParams)

--- a/processor/tile_types.go
+++ b/processor/tile_types.go
@@ -7,9 +7,10 @@ import (
 )
 
 type ScaleParams struct {
-	Offset float64
-	Scale  float64
-	Clip   float64
+	Offset      float64
+	Scale       float64
+	Clip        float64
+	ColourScale int
 }
 
 type ConfigPayLoad struct {

--- a/utils/config.go
+++ b/utils/config.go
@@ -26,6 +26,8 @@ var EtcDir = "."
 var DataDir = "."
 
 const ReservedMemorySize = 1.5 * 1024 * 1024 * 1024
+const ColourLinearScale = 0
+const ColourLogScale = 1
 
 type ServiceConfig struct {
 	OWSHostname       string `json:"ows_hostname"`
@@ -147,6 +149,7 @@ type Layer struct {
 	WmsAxisMapping               int          `json:"wms_axis_mapping"`
 	GrpcTileXSize                float64      `json:"grpc_tile_x_size"`
 	GrpcTileYSize                float64      `json:"grpc_tile_y_size"`
+	ColourScale                  int          `json:"colour_scale"`
 }
 
 // Process contains all the details that a WPS needs


### PR DESCRIPTION
This PR adds support for rendering WMS images in logarithmic scale. This feature is essential for rendering data with different orders of magnitude. e.g. magnetotelluric conductivity models