### PR TITLE
added support for targeting netCDF metadata

### DIFF
--- a/crawl/extractor/info.go
+++ b/crawl/extractor/info.go
@@ -139,7 +139,7 @@ func getDataSetInfo(filename string, dsName *C.char, driverName string, approx b
 	var ncTimes []string
 	var err error
 	var times []time.Time
-	if driverName == "netCDF" || driverName == "JP2OpenJPEG" {
+	if ruleSet.NcMetadata || driverName == "netCDF" || driverName == "JP2OpenJPEG" {
 		ncTimes, err = getNCTime(datasetName, hSubdataset, ruleSet)
 		if err != nil && timeStamp.IsZero() && len(ruleSet.TimesText) == 0 {
 			return &GeoMetaData{}, fmt.Errorf("Error parsing dates: %v", err)
@@ -169,7 +169,7 @@ func getDataSetInfo(filename string, dsName *C.char, driverName string, approx b
 	}
 
 	var ncAxes []*DatasetAxis
-	if driverName == "netCDF" || driverName == "JP2OpenJPEG" {
+	if ruleSet.NcMetadata || driverName == "netCDF" || driverName == "JP2OpenJPEG" {
 		if ruleSet.TimeAxis != nil {
 			if len(ruleSet.TimeAxis.Shape) == 0 || ruleSet.TimeAxis.Shape[0] < 0 {
 				ruleSet.TimeAxis.Shape = []int{len(times)}

--- a/crawl/extractor/ruleset.go
+++ b/crawl/extractor/ruleset.go
@@ -32,6 +32,7 @@ type RuleSet struct {
 	BBox         []float64      `json:"bbox"`
 	GeoLoc       *GeoLocRule    `json:"geo_loc"`
 	AxesText     []*DatasetAxis `json:"axes_text,omitempty"`
+	NcMetadata   bool           `json:"nc_metadata"`
 }
 
 /***** An example config file for the eReefs dataset


### PR DESCRIPTION
This PR adds support for targeting netCDF metadata. This is useful for VRT XML derived from netCDF files.