### PR TITLE
added support for generic crawler

### DIFF
--- a/crawl/crawl_pipeline.sh
+++ b/crawl/crawl_pipeline.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+gsky_crawler=${CRAWL_BIN:-gsky-crawl}
 set -e
 which concurrent
-which gsky-crawl
+[[ "$gsky_crawler" = "gsky-crawl" ]] && which gsky-crawl
 set +e
 
 conc_limit=${CRAWL_CONC_LIMIT:-16}
@@ -51,12 +52,14 @@ echo "INFO: crawl output file: $crawl_file"
 
 gdal_json() {
 	src_file="$1"
-	json=$(gsky-crawl $src_file $CRAWL_EXTRA_ARGS)
+	json=$($gsky_crawler $src_file $CRAWL_EXTRA_ARGS)
 	echo -e "$src_file\tgdal\t$json"
 }
 
 export -f gdal_json
+export gsky_crawler=$gsky_crawler
 export GDAL_PAM_ENABLED=NO
+export GDAL_NETCDF_VERIFY_DIMS=NO
 
 cat $file_list | concurrent -i -l $conc_limit xargs bash -c 'gdal_json "$@"' _ | gzip > $crawl_file
 


### PR DESCRIPTION
This PR adds support for generic crawler via setting the `CRAWL_BIN` environment variable. This feature is useful for crawlers other than the default `gsky-crawl` utility, as long as the json outputs of the crawler are MAS compatible.