### PR TITLE
Crawl stops on error

### DIFF
--- a/crawl/crawl_pipeline.sh
+++ b/crawl/crawl_pipeline.sh
@@ -51,8 +51,10 @@ echo "INFO: file list to crawl: $file_list"
 echo "INFO: crawl output file: $crawl_file"
 
 gdal_json() {
+  set -e
 	src_file="$1"
 	json=$($gsky_crawler $src_file $CRAWL_EXTRA_ARGS)
+  [[ -z "$json" ]] && exit 1
 	echo -e "$src_file\tgdal\t$json"
 }
 

--- a/crawl/crawl_pipeline.sh
+++ b/crawl/crawl_pipeline.sh
@@ -51,10 +51,10 @@ echo "INFO: file list to crawl: $file_list"
 echo "INFO: crawl output file: $crawl_file"
 
 gdal_json() {
-  set -e
+	set -e
 	src_file="$1"
 	json=$($gsky_crawler $src_file $CRAWL_EXTRA_ARGS)
-  [[ -z "$json" ]] && exit 1
+	[[ -z "$json" ]] && exit 1
 	echo -e "$src_file\tgdal\t$json"
 }
 


### PR DESCRIPTION
This PR adds support for crawl (aka. `gdal_json()`) to stop on error to prevent emiting garbage gdal json.