### PR TITLE
Timestamps on demand

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -138,24 +138,10 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			return
 		}
 
-		newConf := &utils.Config{}
-		newConf.ServiceConfig = conf.ServiceConfig
-		for _, layer := range conf.Layers {
-			newLayer := utils.Layer{
-				Name: layer.Name,
-				Title: layer.Title,
-				Abstract: layer.Abstract,
-				Styles: layer.Styles,
-				AxesInfo: layer.AxesInfo,
-			}
-			newConf.Layers = append(newConf.Layers, newLayer)
-		}
-		conf = newConf
-
+		conf = conf.Copy()
 		for iLayer := range conf.Layers {
 			conf.GetLayerDates(iLayer, *verbose)
 		}
-		
 
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 		err := utils.ExecuteWriteTemplateFile(w, conf,
@@ -495,11 +481,9 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 			return
 		}
 
-		newConf := *conf
-		newConf.Layers = make([]utils.Layer, len(newConf.Layers))
-		for i, layer := range conf.Layers {
+		newConf := conf.Copy()
+		for i := range newConf.Layers {
 			conf.GetLayerDates(i, *verbose)
-			newConf.Layers[i] = layer
 			newConf.Layers[i].Dates = []string{newConf.Layers[i].Dates[0], newConf.Layers[i].Dates[len(newConf.Layers[i].Dates)-1]}
 		}
 

--- a/ows.go
+++ b/ows.go
@@ -138,9 +138,24 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			return
 		}
 
+		newConf := &utils.Config{}
+		newConf.ServiceConfig = conf.ServiceConfig
+		for _, layer := range conf.Layers {
+			newLayer := utils.Layer{
+				Name: layer.Name,
+				Title: layer.Title,
+				Abstract: layer.Abstract,
+				Styles: layer.Styles,
+				AxesInfo: layer.AxesInfo,
+			}
+			newConf.Layers = append(newConf.Layers, newLayer)
+		}
+		conf = newConf
+
 		for iLayer := range conf.Layers {
 			conf.GetLayerDates(iLayer, *verbose)
 		}
+		
 
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 		err := utils.ExecuteWriteTemplateFile(w, conf,

--- a/utils/config.go
+++ b/utils/config.go
@@ -150,6 +150,7 @@ type Layer struct {
 	GrpcTileXSize                float64      `json:"grpc_tile_x_size"`
 	GrpcTileYSize                float64      `json:"grpc_tile_y_size"`
 	ColourScale                  int          `json:"colour_scale"`
+	TimestampsLoadStrategy       string       `json:"timestamps_load_strategy"`
 }
 
 // Process contains all the details that a WPS needs
@@ -928,7 +929,9 @@ func (config *Config) LoadConfigFile(configFile string, verbose bool) error {
 		}
 		config.Layers[i].FeatureInfoExpressions = featureInfoExpr
 
-		config.GetLayerDates(i, verbose)
+		if config.Layers[i].TimestampsLoadStrategy != "on_demand" {
+			config.GetLayerDates(i, verbose)
+		}
 
 		config.Layers[i].OWSHostname = config.ServiceConfig.OWSHostname
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -640,6 +640,44 @@ const DefaultWcsMaxTileHeight = 1024
 const DefaultLegendWidth = 160
 const DefaultLegendHeight = 320
 
+// CopyConfig makes a deep copy of the certain fields of the config object.
+// For the time being, we only copy the fields required for GetCapabilities.
+func (config *Config) Copy() *Config {
+	newConf := &Config{}
+	newConf.ServiceConfig = ServiceConfig{
+		OWSHostname: config.ServiceConfig.OWSHostname,
+		NameSpace:   config.ServiceConfig.NameSpace,
+		MASAddress:  config.ServiceConfig.MASAddress,
+	}
+
+	newConf.Layers = make([]Layer, len(config.Layers))
+	for i, layer := range config.Layers {
+		if len(layer.InputLayers) > 0 && len(strings.TrimSpace(layer.DataSource)) == 0 {
+			newConf.Layers[i] = layer
+			continue
+		}
+		newConf.Layers[i] = Layer{
+			Name:           layer.Name,
+			Title:          layer.Title,
+			Abstract:       layer.Abstract,
+			NameSpace:      layer.NameSpace,
+			Styles:         layer.Styles,
+			AxesInfo:       layer.AxesInfo,
+			StepDays:       layer.StepDays,
+			StepHours:      layer.StepHours,
+			StepMinutes:    layer.StepMinutes,
+			StartISODate:   layer.StartISODate,
+			EndISODate:     layer.EndISODate,
+			TimeGen:        layer.TimeGen,
+			Accum:          layer.Accum,
+			DataSource:     layer.DataSource,
+			RGBExpressions: layer.RGBExpressions,
+		}
+	}
+
+	return newConf
+}
+
 // GetLayerDates loads dates for the ith layer
 func (config *Config) GetLayerDates(iLayer int, verbose bool) {
 	layer := config.Layers[iLayer]


### PR DESCRIPTION
This PR adds support for loading timestamps on demand. For datasets such as the climate ones with large volume of timestamps, it is not possible to pre-load all the timestamps and cache them in memory during GSKY startup. Therefore, we only load the timestamps when GetCapabilities is called and discard the timestamps after the call returns.