### PR TITLE
fixed on-demand timestamps token

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -674,6 +674,7 @@ func (config *Config) Copy() *Config {
 			DataSource:     layer.DataSource,
 			RGBExpressions: layer.RGBExpressions,
 			TimestampToken: layer.TimestampToken,
+			Dates:          layer.Dates,
 		}
 	}
 


### PR DESCRIPTION
This PR fixes `TimestampsToken` passing for on-demand timestamps loading. 