### PR TITLE
disable overview extrapolation for wcs by default

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -343,7 +343,7 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 		masAddress := styleLayer.MASAddress
 		hasOverview := len(styleLayer.Overviews) > 0
 		if hasOverview {
-			iOvr := utils.FindLayerBestOverview(styleLayer, reqRes)
+			iOvr := utils.FindLayerBestOverview(styleLayer, reqRes, true)
 			if iOvr >= 0 {
 				ovr := styleLayer.Overviews[iOvr]
 				geoReq.Collection = ovr.DataSource
@@ -901,7 +901,7 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 				bbox, err := utils.GetCanonicalBbox(geoReq.CRS, geoReq.BBox)
 				if err == nil {
 					reqRes := utils.GetPixelResolution(bbox, geoReq.Width, geoReq.Height)
-					iOvr := utils.FindLayerBestOverview(styleLayer, reqRes)
+					iOvr := utils.FindLayerBestOverview(styleLayer, reqRes, false)
 					if iOvr >= 0 {
 						ovr := styleLayer.Overviews[iOvr]
 						geoReq.Collection = ovr.DataSource

--- a/processor/feature_info.go
+++ b/processor/feature_info.go
@@ -272,7 +272,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	masAddress := styleLayer.MASAddress
 	hasOverview := len(styleLayer.Overviews) > 0
 	if hasOverview {
-		iOvr := utils.FindLayerBestOverview(styleLayer, reqRes)
+		iOvr := utils.FindLayerBestOverview(styleLayer, reqRes, true)
 		if iOvr >= 0 {
 			ovr := styleLayer.Overviews[iOvr]
 			geoReq.Collection = ovr.DataSource

--- a/processor/tile_pipeline.go
+++ b/processor/tile_pipeline.go
@@ -363,7 +363,7 @@ func (dp *TilePipeline) prepareInputGeoRequests(geoReq *GeoTileRequest, depLayer
 		if useOverview {
 			hasOverview := len(styleLayer.Overviews) > 0
 			if hasOverview {
-				iOvr := utils.FindLayerBestOverview(styleLayer, geoReq.ReqRes)
+				iOvr := utils.FindLayerBestOverview(styleLayer, geoReq.ReqRes, true)
 				if iOvr >= 0 {
 					ovr := styleLayer.Overviews[iOvr]
 					ctx.GeoReq.Collection = ovr.DataSource

--- a/utils/wms.go
+++ b/utils/wms.go
@@ -485,9 +485,15 @@ func GetPixelResolution(bbox []float64, width int, height int) float64 {
 	return reqRes
 }
 
-func FindLayerBestOverview(layer *Layer, reqRes float64) int {
+func FindLayerBestOverview(layer *Layer, reqRes float64, allowExtrapolation bool) int {
 	bestOvr := -1
 	if reqRes > layer.ZoomLimit {
+		if !allowExtrapolation {
+			if layer.Overviews[0].ZoomLimit > reqRes {
+				return -1
+			}
+		}
+
 		iOvr := 0
 		for i := 0; i < len(layer.Overviews); i++ {
 			if layer.Overviews[i].ZoomLimit > layer.ZoomLimit {


### PR DESCRIPTION
This PR disables overview extrapolation for WCS by default