### PR TITLE
properly handled timezones when converting from unix into golang timestamps

### DIFF
--- a/processor/feature_info.go
+++ b/processor/feature_info.go
@@ -336,7 +336,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 			continue
 		}
 
-		tm := time.Unix(int64(geo.TimeStamp), 0)
+		tm := time.Unix(int64(geo.TimeStamp), 0).UTC()
 		normalizedTm := time.Date(tm.Year(), tm.Month(), tm.Day(), 0, 0, 0, 0, time.UTC)
 		if _, found := timestampLookup[normalizedTm]; found {
 			continue
@@ -357,7 +357,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 		}
 		for i := range pixelFiles[:maxDates] {
 			ts := pixelFiles[maxDates-1-i].TimeStamp
-			tm := time.Unix(int64(ts), 0)
+			tm := time.Unix(int64(ts), 0).UTC()
 			normalizedTm := time.Date(tm.Year(), tm.Month(), tm.Day(), 0, 0, 0, 0, time.UTC).Format(dateFormat)
 			topDsDates = append(topDsDates, normalizedTm)
 		}

--- a/processor/tile_indexer.go
+++ b/processor/tile_indexer.go
@@ -133,12 +133,12 @@ func (p *TileIndexer) Run(verbose bool) {
 						}
 					} else {
 						if axis.Start != nil {
-							minTime := time.Unix(int64(*axis.Start), 0)
+							minTime := time.Unix(int64(*axis.Start), 0).UTC()
 							geoReq.StartTime = &minTime
 						}
 
 						if axis.End != nil {
-							maxTime := time.Unix(int64(*axis.End), 0)
+							maxTime := time.Unix(int64(*axis.End), 0).UTC()
 							geoReq.EndTime = &maxTime
 						}
 					}
@@ -412,7 +412,7 @@ func URLIndexGet(ctx context.Context, url string, geoReq *GeoTileRequest, errCha
 
 						var readableNs string
 						if ds.Axes[i].Name == "time" {
-							ts := time.Unix(int64(ds.Axes[i].IntersectionValues[axisIdxCnt[i]]), 0)
+							ts := time.Unix(int64(ds.Axes[i].IntersectionValues[axisIdxCnt[i]]), 0).UTC()
 							readableNs = fmt.Sprintf("%v", ts.Format(ISOFormat))
 						} else {
 							readableNs = fmt.Sprintf("%v", ds.Axes[i].IntersectionValues[axisIdxCnt[i]])


### PR DESCRIPTION
As we do not assume timezones when dealing with the timestamps, converting from unix timestamps into golang datetimes must be done without timezones. Otherwise the original and the converted timestamps will not be consistent.