### PR TITLE
properly initialising wcs temp file when the first tile is empty

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -1004,6 +1004,13 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 			select {
 			case res := <-tp.Process(geoReq, *verbose):
 				if !isInit {
+					if ir < len(workerTileRequests[0])-1 {
+						isEmptyTile, _ := utils.CheckEmptyTile(res)
+						if isEmptyTile {
+							continue
+						}
+					}
+
 					hDstDS, masterTempFile, err = utils.EncodeGdalOpen(conf.ServiceConfig.TempDir, 1024, 256, driverFormat, geot, epsg, res, *params.Width, *params.Height, len(res))
 					if err != nil {
 						utils.RemoveGdalTempFile(masterTempFile)

--- a/utils/ogc_encoders.go
+++ b/utils/ogc_encoders.go
@@ -541,6 +541,36 @@ func ExtractEPSGCode(srs string) (int, error) {
 	return strconv.Atoi(srs[5:])
 }
 
+func CheckEmptyTile(rs []Raster) (bool, error) {
+	for _, r := range rs {
+		switch t := r.(type) {
+		case *SignedByteRaster:
+			if isEmptyTile(t.NameSpace) {
+				return true, nil
+			}
+		case *ByteRaster:
+			if isEmptyTile(t.NameSpace) {
+				return true, nil
+			}
+		case *Int16Raster:
+			if isEmptyTile(t.NameSpace) {
+				return true, nil
+			}
+		case *UInt16Raster:
+			if isEmptyTile(t.NameSpace) {
+				return true, nil
+			}
+		case *Float32Raster:
+			if isEmptyTile(t.NameSpace) {
+				return true, nil
+			}
+		default:
+			return false, fmt.Errorf("Raster type not implemented")
+		}
+	}
+	return false, nil
+}
+
 func isEmptyTile(namespace string) bool {
 	return len(namespace) >= len(EmptyTileNS) && namespace[:len(EmptyTileNS)] == EmptyTileNS
 }


### PR DESCRIPTION
This PR properly initialises WCS temp file when the first tile is empty. Previously WCS initialises the number of bands of the temp file against the first tile. This is inadequate if the first tile happens to be an empty tile with a single band while one of subsequent tiles is non-empty with arbitrary number of bands.