### PR TITLE
added support for filtering out unwanted URL parameters for metrics logging

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -60,6 +60,8 @@ type MetricsCollector struct {
 	logger Logger
 }
 
+var reservedQueryParams = map[string]bool{"bbox": true, "coverage": true, "crs": true, "dptol": true, "height": true, "identifier": true, "identitytol": true, "layer": true, "layers": true, "limit": true, "namespace": true, "nseg": true, "request": true, "service": true, "srs": true, "styles": true, "time": true, "until": true, "version": true, "width": true, "wkt": true}
+
 func NewMetricsCollector(logger Logger) *MetricsCollector {
 	return &MetricsCollector{
 		Info: &MetricsInfo{
@@ -136,6 +138,9 @@ func (i *MetricsInfo) normaliseURL(u *URLInfo) error {
 		u.Query = make(map[string]string)
 	}
 	for k, v := range query {
+		if _, found := reservedQueryParams[k]; !found {
+			continue
+		}
 		if len(v) == 1 {
 			u.Query[k] = v[0]
 		} else if len(v) > 1 {

--- a/ows.go
+++ b/ows.go
@@ -1504,6 +1504,18 @@ func generalHandler(conf *utils.Config, w http.ResponseWriter, r *http.Request) 
 		serveWCS(ctx, params, conf, r.URL.String(), w, query, metricsCollector)
 	case "WPS":
 		params, err := utils.WPSParamsChecker(query, reWPSMap)
+		if _, hasId := query["identifier"]; hasId && r.Method == "POST" {
+			if params.Identifier != nil {
+				url := metricsCollector.Info.URL.RawURL
+				var sep string
+				if len(query) > 0 {
+					sep = "&"
+				} else {
+					sep = "?"
+				}
+				metricsCollector.Info.URL.RawURL = fmt.Sprintf("%s%sidentifier=%s", url, sep, *params.Identifier)
+			}
+		}
 		if err != nil {
 			metricsCollector.Info.HTTPStatus = 400
 			http.Error(w, fmt.Sprintf("Wrong WPS parameters on URL: %s", err), 400)


### PR DESCRIPTION
This PR support for filtering out unwanted URL parameters for metrics logging. This is essential to prevent large URLs to flood the metrics logs.