### PR TITLE
removed grouping rpc by polygon

### DIFF
--- a/processor/tile_merger.go
+++ b/processor/tile_merger.go
@@ -444,7 +444,7 @@ func ComputeMask(mask *utils.Mask, data []byte, rType string) (out []bool, err e
 	return
 }
 
-func (enc *RasterMerger) Run(polyLimiter *ConcLimiter, bandExpr *utils.BandExpressions, verbose bool) {
+func (enc *RasterMerger) Run(bandExpr *utils.BandExpressions, verbose bool) {
 	if verbose {
 		defer log.Printf("tile merger done")
 	}
@@ -454,7 +454,6 @@ func (enc *RasterMerger) Run(polyLimiter *ConcLimiter, bandExpr *utils.BandExpre
 	for inRasters := range enc.In {
 		select {
 		case <-enc.Context.Done():
-			polyLimiter.Decrease()
 			return
 		default:
 		}
@@ -496,8 +495,6 @@ func (enc *RasterMerger) Run(polyLimiter *ConcLimiter, bandExpr *utils.BandExpre
 			}
 			canvasMap = tmpMap
 		}
-
-		polyLimiter.Decrease()
 	}
 
 	select {

--- a/processor/tile_pipeline.go
+++ b/processor/tile_pipeline.go
@@ -57,8 +57,7 @@ func (dp *TilePipeline) Process(geoReq *GeoTileRequest, verbose bool) chan []uti
 	grpcTiler.In = i.Out
 	m.In = grpcTiler.Out
 
-	polyLimiter := NewConcLimiter(dp.PolygonShardConcLimit)
-	go m.Run(polyLimiter, geoReq.BandExpr, verbose)
+	go m.Run(geoReq.BandExpr, verbose)
 
 	varList := geoReq.BandExpr.VarList
 	if dp.CurrentLayer != nil && len(dp.CurrentLayer.InputLayers) > 0 {
@@ -124,7 +123,6 @@ func (dp *TilePipeline) Process(geoReq *GeoTileRequest, verbose bool) chan []uti
 					}
 				}
 
-				polyLimiter.Increase()
 				m.In <- rasters
 			}
 
@@ -142,7 +140,7 @@ func (dp *TilePipeline) Process(geoReq *GeoTileRequest, verbose bool) chan []uti
 	}()
 
 	go i.Run(verbose)
-	go grpcTiler.Run(polyLimiter, varList, verbose)
+	go grpcTiler.Run(varList, verbose)
 
 	return m.Out
 }


### PR DESCRIPTION
This PR removes grouping RPC calls by polygon. Grouping RPC by polygon only works assuming no intersection among polygons. This assumption is broken for a few datasets. 