### PR TITLE
added support for pseudo-style as a service

### DIFF
--- a/processor/feature_info.go
+++ b/processor/feature_info.go
@@ -326,6 +326,12 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	if conf.Layers[idx].FeatureInfoMaxAvailableDates != 0 {
 		geoReq.StartTime = &time.Time{}
 		currTime, _ := time.Parse(ISOFormat, conf.Layers[idx].Dates[len(conf.Layers[idx].Dates)-1])
+		step := 60*24*conf.Layers[idx].StepDays + 60*conf.Layers[idx].StepHours + conf.Layers[idx].StepMinutes
+		if step <= 0 {
+			step = 1
+		}
+		timeStep := time.Minute * time.Duration(step)
+		currTime = currTime.Add(timeStep)
 		geoReq.EndTime = &currTime
 	}
 

--- a/templates/WMS_GetCapabilities.tpl
+++ b/templates/WMS_GetCapabilities.tpl
@@ -117,6 +117,7 @@
 				</DataURL>
 				
 				{{ range $styleIdx, $style := $value.Styles }}
+					{{if .Visibility }}
 					<Style>
 						<Name>{{ .Name }}</Name>
 						<Title>{{ .Title }}</Title>
@@ -128,6 +129,7 @@
 						</LegendURL>
 						{{end}}
 					</Style>
+					{{end}}
 				{{end}}
 			</Layer>
 			{{end}}

--- a/utils/config.go
+++ b/utils/config.go
@@ -171,6 +171,7 @@ type Layer struct {
 	TimestampsLoadStrategy       string       `json:"timestamps_load_strategy"`
 	MasQueryHint                 string       `json:"mas_query_hint"`
 	SRSCf                        int          `json:"srs_cf"`
+	Visibility                   string       `json:"visibility"`
 }
 
 // Process contains all the details that a WPS needs
@@ -567,6 +568,10 @@ func LoadAllConfigFiles(rootDir string, verbose bool) (map[string]*Config, error
 
 					if config.Layers[i].Styles[j].ZoomLimit == 0.0 && config.Layers[i].ZoomLimit != 0.0 {
 						config.Layers[i].Styles[j].ZoomLimit = config.Layers[i].ZoomLimit
+					}
+
+					if !strings.HasPrefix(config.Layers[i].Styles[j].Name, "__") {
+						config.Layers[i].Styles[j].Visibility = "visible"
 					}
 				}
 			}

--- a/utils/wms.go
+++ b/utils/wms.go
@@ -395,6 +395,15 @@ func GetLayerIndex(params WMSParams, config *Config) (int, error) {
 func GetLayerStyleIndex(params WMSParams, config *Config, layerIdx int) (int, error) {
 	if params.Styles != nil {
 		style := strings.TrimSpace(params.Styles[0])
+		if !strings.HasPrefix(style, "__tw__") {
+			for _, axis := range params.Axes {
+				if axis.Name == WeightedTimeAxis {
+					style = "__tw__" + style
+					break
+				}
+			}
+		}
+
 		if len(style) == 0 {
 			if len(config.Layers[layerIdx].Styles) > 0 {
 				return 0, nil


### PR DESCRIPTION
This PR adds support for pseudo-style as a service. This feature, for example, enables attaching delta style as a service to the corresponding underlying style.