### PR TITLE
added support for batch crawler

### DIFF
--- a/crawl/crawl.go
+++ b/crawl/crawl.go
@@ -35,6 +35,7 @@ func main() {
 	landsatYaml := false
 	var configFile string
 	ncMetadata := false
+	var outputFormat string
 
 	if len(os.Args) > 2 {
 		flagSet := flag.NewFlagSet("Usage", flag.ExitOnError)
@@ -45,9 +46,19 @@ func main() {
 		flagSet.StringVar(&configFile, "conf", "", "Crawl config file")
 		flagSet.BoolVar(&ncMetadata, "nc_md", false, "Look for netCDF metadata")
 		flagSet.BoolVar(&landsatYaml, "landsat_yaml", false, "Extract landsat metadata from its yaml files")
+		flagSet.StringVar(&outputFormat, "fmt", "raw", "Output format. Valid values include raw and tsv")
 		flagSet.Parse(os.Args[2:])
 
 		approx = !exact
+	}
+
+	outputFormat = strings.ToLower(strings.TrimSpace(outputFormat))
+	if len(outputFormat) == 0 {
+		outputFormat = "raw"
+	}
+
+	if outputFormat != "raw" && outputFormat != "tsv" {
+		log.Fatal("Valid output formats are raw and tsv")
 	}
 
 	var err error
@@ -107,11 +118,16 @@ func main() {
 			out, err := json.Marshal(&geoFile)
 			ensure(err)
 
+			outStr := string(out)
+			if outputFormat == "tsv" {
+				outStr = fmt.Sprintf("%s\tgdal\t%s", path, string(out))
+			}
+
 			var rec string
 			if iPath < len(pathList)-1 {
-				rec = fmt.Sprintf("%s\n", string(out))
+				rec = fmt.Sprintf("%s\n", outStr)
 			} else {
-				rec = fmt.Sprintf("%s", string(out))
+				rec = fmt.Sprintf("%s", outStr)
 			}
 			fmt.Print(rec)
 		} else {

--- a/crawl/crawl.go
+++ b/crawl/crawl.go
@@ -82,8 +82,7 @@ func main() {
 	}
 
 	var cfg []byte
-	var iPath int
-	for iPath, path = range pathList {
+	for _, path = range pathList {
 		var geoFile *extr.GeoFile
 		if sentinel2Yaml {
 			geoFile, err = extr.ExtractYaml(path, "sentinel2")
@@ -118,17 +117,11 @@ func main() {
 			out, err := json.Marshal(&geoFile)
 			ensure(err)
 
-			outStr := string(out)
+			rec := string(out)
 			if outputFormat == "tsv" {
-				outStr = fmt.Sprintf("%s\tgdal\t%s", path, string(out))
+				rec = fmt.Sprintf("%s\tgdal\t%s\n", path, string(out))
 			}
 
-			var rec string
-			if iPath < len(pathList)-1 {
-				rec = fmt.Sprintf("%s\n", outStr)
-			} else {
-				rec = fmt.Sprintf("%s", outStr)
-			}
 			fmt.Print(rec)
 		} else {
 			os.Stderr.Write([]byte(err.Error()))


### PR DESCRIPTION
This PR adds support for batch crawler. Batch crawler significantly improves crawling performance by reducing the overhead of launching the `gsky-crawl` process repetitively.