### PR TITLE
pruning refreshing views

### DIFF
--- a/mas/db/shard_refresh.sh
+++ b/mas/db/shard_refresh.sh
@@ -8,7 +8,6 @@ shard=$1
 set role mas;
 set search_path to ${shard};
 
-select refresh_views();
 select refresh_polygons();
 select refresh_caches();
 


### PR DESCRIPTION
This PR prunes `refresh_views()` to improve ingestion performance. Users can perform ad-hoc `refresh_views()` when needed.