### PR TITLE
interleave processing between indexer and grpc

### DIFF
--- a/processor/tile_grpc.go
+++ b/processor/tile_grpc.go
@@ -54,21 +54,14 @@ func (gi *GeoRasterGRPC) Run(varList []string, verbose bool) {
 	var nullGrans []*GeoTileGranule
 	availNamespaces := make(map[string]bool)
 	dedupGrans := make(map[string]bool)
-	i := 0
 	for gran := range gi.In {
 		if gran.Path != "NULL" {
 			granKey := fmt.Sprintf("%s_%d", gran.Path, gran.BandIdx)
-			if _, hasGran := dedupGrans[granKey]; hasGran {
-				continue
-			}
 			dedupGrans[granKey] = true
-
+			availNamespaces[gran.VarNameSpace] = true
 			grans = append(grans, gran)
-			if _, found := availNamespaces[gran.VarNameSpace]; !found {
-				availNamespaces[gran.VarNameSpace] = true
-			}
 
-			i++
+			break
 		} else {
 			if len(nullGrans) == 0 {
 				nullGrans = append(nullGrans, gran)
@@ -84,86 +77,9 @@ func (gi *GeoRasterGRPC) Run(varList []string, verbose bool) {
 		return
 	}
 
-	if verbose {
-		log.Printf("tile grpc: %v effective granules", len(grans))
-	}
-
-	for _, v := range varList {
-		if _, found := availNamespaces[v]; !found {
-			gi.sendError(fmt.Errorf("band '%v' not found", v))
-			return
-		}
-	}
-
 	g0 := grans[0]
-	effectivePoolSize := int(math.Ceil(float64(len(grans)) / float64(g0.GrpcConcLimit)))
-	if effectivePoolSize < 1 {
-		effectivePoolSize = 1
-	} else if effectivePoolSize > len(gi.Clients) {
-		effectivePoolSize = len(gi.Clients)
-	}
-
 	if g0.MetricsCollector != nil {
 		defer func() { g0.MetricsCollector.Info.RPC.Duration += time.Since(t0) }()
-	}
-
-	if g0.GrpcTileXSize > 0.0 || g0.GrpcTileYSize > 0.0 {
-		maxXTileSize := g0.Width
-		if g0.GrpcTileXSize <= 0.0 {
-			maxXTileSize = g0.Width
-		} else if g0.GrpcTileXSize <= 1.0 {
-			maxXTileSize = int(float64(g0.Width) * g0.GrpcTileXSize)
-		} else if g0.GrpcTileXSize < float64(g0.Width) {
-			maxXTileSize = int(g0.GrpcTileXSize)
-		}
-
-		maxYTileSize := g0.Height
-		if g0.GrpcTileYSize <= 0.0 {
-			maxYTileSize = g0.Height
-		} else if g0.GrpcTileYSize <= 1.0 {
-			maxYTileSize = int(float64(g0.Height) * g0.GrpcTileYSize)
-		} else if g0.GrpcTileYSize < float64(g0.Height) {
-			maxYTileSize = int(g0.GrpcTileYSize)
-		}
-
-		var tmpGrans []*GeoTileGranule
-		for _, g := range grans {
-			tmpGrans = append(tmpGrans, g)
-		}
-
-		if verbose {
-			log.Printf("tile grpc maxTileSize: %v, %v", maxXTileSize, maxYTileSize)
-		}
-
-		grans = nil
-		for _, g := range tmpGrans {
-			xRes := (g.BBox[2] - g.BBox[0]) / float64(g.Width)
-			yRes := (g.BBox[3] - g.BBox[1]) / float64(g.Height)
-
-			for y := 0; y < g.Height; y += maxYTileSize {
-				for x := 0; x < g.Width; x += maxXTileSize {
-					yMin := g.BBox[1] + float64(y)*yRes
-					yMax := math.Min(g.BBox[1]+float64(y+maxYTileSize)*yRes, g.BBox[3])
-					xMin := g.BBox[0] + float64(x)*xRes
-					xMax := math.Min(g.BBox[0]+float64(x+maxXTileSize)*xRes, g.BBox[2])
-
-					tileXSize := int(.5 + (xMax-xMin)/xRes)
-					tileYSize := int(.5 + (yMax-yMin)/yRes)
-
-					tileGran := &GeoTileGranule{ConfigPayLoad: g.ConfigPayLoad, RawPath: g.RawPath, Path: g.Path, NameSpace: g.NameSpace, VarNameSpace: g.VarNameSpace, RasterType: g.RasterType, TimeStamp: g.TimeStamp, BandIdx: g.BandIdx, Polygon: g.Polygon, BBox: []float64{xMin, yMin, xMax, yMax}, Height: tileYSize, Width: tileXSize, RawHeight: g.Height, RawWidth: g.Width, OffX: x, OffY: g.Height - y - tileYSize, CRS: g.CRS, SrcSRS: g.SrcSRS, SrcGeoTransform: g.SrcGeoTransform, GeoLocation: g.GeoLocation}
-					grans = append(grans, tileGran)
-				}
-			}
-
-		}
-
-		if verbose {
-			log.Printf("tile grpc: %v tiled granules", len(grans))
-		}
-	}
-
-	if g0.MetricsCollector != nil {
-		g0.MetricsCollector.Info.RPC.NumTiledGranules += len(grans)
 	}
 
 	accumMetrics := &pb.WorkerMetrics{}
@@ -187,6 +103,8 @@ func (gi *GeoRasterGRPC) Run(varList []string, verbose bool) {
 	rand.Shuffle(len(clientIdx), func(i, j int) { clientIdx[i], clientIdx[j] = clientIdx[j], clientIdx[i] })
 
 	var connPool []*grpc.ClientConn
+
+	effectivePoolSize := len(gi.Clients)
 	for i := 0; i < effectivePoolSize; i++ {
 		conn, err := grpc.Dial(gi.Clients[clientIdx[i]], opts...)
 		if err != nil {
@@ -214,50 +132,134 @@ func (gi *GeoRasterGRPC) Run(varList []string, verbose bool) {
 	projWKT := C.GoString(projWKTC)
 
 	cLimiter := NewConcLimiter(g0.GrpcConcLimit * len(connPool))
-	outRasters := make([]*FlexRaster, len(grans))
-	outMetrics := make([]*pb.WorkerMetrics, len(grans))
+
+	var outRasters []*FlexRaster
+	var outMetrics []*pb.WorkerMetrics
+
+	iGran := 0
 
 	var wgRpc sync.WaitGroup
-	for iGran := range grans {
-		gran := grans[iGran]
-		select {
-		case <-gi.Context.Done():
-			return
-		default:
-			if gran.Path == "NULL" {
-				outRasters[iGran] = &FlexRaster{ConfigPayLoad: gran.ConfigPayLoad, Data: make([]uint8, gran.Width*gran.Height), Height: gran.Height, Width: gran.Width, OffX: gran.OffX, OffY: gran.OffY, Type: gran.RasterType, NoData: 0.0, NameSpace: gran.NameSpace, TimeStamp: gran.TimeStamp, Polygon: gran.Polygon}
-				continue
-			}
-
-			wgRpc.Add(1)
-			cLimiter.Increase()
-			go func(g *GeoTileGranule, idx int) {
-				defer wgRpc.Done()
-				defer cLimiter.Decrease()
-				r, err := getRPCRaster(gi.Context, g, projWKT, connPool[idx%len(connPool)])
-				if err != nil {
-					gi.sendError(err)
-					r = &pb.Result{Raster: &pb.Raster{Data: make([]uint8, g.Width*g.Height), RasterType: "Byte", NoData: -1.}}
-				}
-				outMetrics[idx] = r.Metrics
-				if len(r.Raster.Bbox) == 0 {
-					r.Raster.Bbox = []int32{0, 0, int32(g.Width), int32(g.Height)}
-				}
-				rOffX := g.OffX + int(r.Raster.Bbox[0])
-				rOffY := g.OffY + int(r.Raster.Bbox[1])
-				rWidth := int(r.Raster.Bbox[2])
-				rHeight := int(r.Raster.Bbox[3])
-				rawHeight := g.Height
-				rawWidth := g.Width
-				if g.RawHeight > 0 && g.RawWidth > 0 {
-					rawHeight = g.RawHeight
-					rawWidth = g.RawWidth
-				}
-				outRasters[idx] = &FlexRaster{ConfigPayLoad: g.ConfigPayLoad, Data: r.Raster.Data, Height: rawHeight, Width: rawWidth, DataHeight: rHeight, DataWidth: rWidth, OffX: rOffX, OffY: rOffY, Type: r.Raster.RasterType, NoData: r.Raster.NoData, NameSpace: g.NameSpace, TimeStamp: g.TimeStamp, Polygon: g.Polygon}
-			}(gran, iGran)
+	for inGran := range gi.In {
+		if inGran.Path == "NULL" {
+			continue
 		}
 
+		granKey := fmt.Sprintf("%s_%d", inGran.Path, inGran.BandIdx)
+		if _, hasGran := dedupGrans[granKey]; hasGran {
+			continue
+		}
+		dedupGrans[granKey] = true
+		grans = append(grans, inGran)
+
+		if _, found := availNamespaces[inGran.VarNameSpace]; !found {
+			availNamespaces[inGran.VarNameSpace] = true
+		}
+
+		if g0.GrpcTileXSize > 0.0 || g0.GrpcTileYSize > 0.0 {
+			maxXTileSize := g0.Width
+			if g0.GrpcTileXSize <= 0.0 {
+				maxXTileSize = g0.Width
+			} else if g0.GrpcTileXSize <= 1.0 {
+				maxXTileSize = int(float64(g0.Width) * g0.GrpcTileXSize)
+			} else if g0.GrpcTileXSize < float64(g0.Width) {
+				maxXTileSize = int(g0.GrpcTileXSize)
+			}
+
+			maxYTileSize := g0.Height
+			if g0.GrpcTileYSize <= 0.0 {
+				maxYTileSize = g0.Height
+			} else if g0.GrpcTileYSize <= 1.0 {
+				maxYTileSize = int(float64(g0.Height) * g0.GrpcTileYSize)
+			} else if g0.GrpcTileYSize < float64(g0.Height) {
+				maxYTileSize = int(g0.GrpcTileYSize)
+			}
+
+			var tmpGrans []*GeoTileGranule
+			for _, g := range grans {
+				tmpGrans = append(tmpGrans, g)
+			}
+
+			if verbose && iGran == 0 {
+				log.Printf("tile grpc maxTileSize: %v, %v", maxXTileSize, maxYTileSize)
+			}
+
+			grans = nil
+			for _, g := range tmpGrans {
+				xRes := (g.BBox[2] - g.BBox[0]) / float64(g.Width)
+				yRes := (g.BBox[3] - g.BBox[1]) / float64(g.Height)
+
+				for y := 0; y < g.Height; y += maxYTileSize {
+					for x := 0; x < g.Width; x += maxXTileSize {
+						yMin := g.BBox[1] + float64(y)*yRes
+						yMax := math.Min(g.BBox[1]+float64(y+maxYTileSize)*yRes, g.BBox[3])
+						xMin := g.BBox[0] + float64(x)*xRes
+						xMax := math.Min(g.BBox[0]+float64(x+maxXTileSize)*xRes, g.BBox[2])
+
+						tileXSize := int(.5 + (xMax-xMin)/xRes)
+						tileYSize := int(.5 + (yMax-yMin)/yRes)
+
+						tileGran := &GeoTileGranule{ConfigPayLoad: g.ConfigPayLoad, RawPath: g.RawPath, Path: g.Path, NameSpace: g.NameSpace, VarNameSpace: g.VarNameSpace, RasterType: g.RasterType, TimeStamp: g.TimeStamp, BandIdx: g.BandIdx, Polygon: g.Polygon, BBox: []float64{xMin, yMin, xMax, yMax}, Height: tileYSize, Width: tileXSize, RawHeight: g.Height, RawWidth: g.Width, OffX: x, OffY: g.Height - y - tileYSize, CRS: g.CRS, SrcSRS: g.SrcSRS, SrcGeoTransform: g.SrcGeoTransform, GeoLocation: g.GeoLocation}
+						grans = append(grans, tileGran)
+					}
+				}
+
+			}
+		}
+
+		for ig := range grans {
+			gran := grans[ig]
+			outRasters = append(outRasters, nil)
+			outMetrics = append(outMetrics, nil)
+			select {
+			case <-gi.Context.Done():
+				return
+			default:
+				if gran.Path == "NULL" {
+					outRasters[iGran] = &FlexRaster{ConfigPayLoad: gran.ConfigPayLoad, Data: make([]uint8, gran.Width*gran.Height), Height: gran.Height, Width: gran.Width, OffX: gran.OffX, OffY: gran.OffY, Type: gran.RasterType, NoData: 0.0, NameSpace: gran.NameSpace, TimeStamp: gran.TimeStamp, Polygon: gran.Polygon}
+					continue
+				}
+
+				wgRpc.Add(1)
+				cLimiter.Increase()
+				go func(g *GeoTileGranule, idx int) {
+					defer wgRpc.Done()
+					defer cLimiter.Decrease()
+					r, err := getRPCRaster(gi.Context, g, projWKT, connPool[idx%len(connPool)])
+					if err != nil {
+						gi.sendError(err)
+						r = &pb.Result{Raster: &pb.Raster{Data: make([]uint8, g.Width*g.Height), RasterType: "Byte", NoData: -1.}}
+					}
+					outMetrics[idx] = r.Metrics
+					if len(r.Raster.Bbox) == 0 {
+						r.Raster.Bbox = []int32{0, 0, int32(g.Width), int32(g.Height)}
+					}
+					rOffX := g.OffX + int(r.Raster.Bbox[0])
+					rOffY := g.OffY + int(r.Raster.Bbox[1])
+					rWidth := int(r.Raster.Bbox[2])
+					rHeight := int(r.Raster.Bbox[3])
+					rawHeight := g.Height
+					rawWidth := g.Width
+					if g.RawHeight > 0 && g.RawWidth > 0 {
+						rawHeight = g.RawHeight
+						rawWidth = g.RawWidth
+					}
+					outRasters[idx] = &FlexRaster{ConfigPayLoad: g.ConfigPayLoad, Data: r.Raster.Data, Height: rawHeight, Width: rawWidth, DataHeight: rHeight, DataWidth: rWidth, OffX: rOffX, OffY: rOffY, Type: r.Raster.RasterType, NoData: r.Raster.NoData, NameSpace: g.NameSpace, TimeStamp: g.TimeStamp, Polygon: g.Polygon}
+				}(gran, iGran)
+			}
+
+			iGran++
+		}
+
+		grans = nil
 	}
+
+	for _, v := range varList {
+		if _, found := availNamespaces[v]; !found {
+			gi.sendError(fmt.Errorf("band '%v' not found", v))
+			return
+		}
+	}
+
 	wgRpc.Wait()
 	for i := 0; i < len(outMetrics); i++ {
 		if outMetrics[i] != nil {
@@ -265,6 +267,14 @@ func (gi *GeoRasterGRPC) Run(varList []string, verbose bool) {
 			accumMetrics.UserTime += outMetrics[i].UserTime
 			accumMetrics.SysTime += outMetrics[i].SysTime
 		}
+	}
+
+	if g0.MetricsCollector != nil {
+		g0.MetricsCollector.Info.RPC.NumTiledGranules += iGran
+	}
+
+	if verbose {
+		log.Printf("tile grpc: %v effective granules", iGran)
 	}
 
 	select {

--- a/processor/tile_indexer.go
+++ b/processor/tile_indexer.go
@@ -74,7 +74,7 @@ func NewTileIndexer(ctx context.Context, apiAddr string, errChan chan error) *Ti
 	return &TileIndexer{
 		Context:    ctx,
 		In:         make(chan *GeoTileRequest, 100),
-		Out:        make(chan *GeoTileGranule, 100),
+		Out:        make(chan *GeoTileGranule, 8192),
 		Error:      errChan,
 		APIAddress: apiAddr,
 	}


### PR DESCRIPTION
This PR adds support for interleaving the processing between `tile_indexer` and `tile_grpc`. Essentially  gRPC doesn't have to wait for the complete results from the indexer but kick start as soon as partial results are available.