### PR TITLE
added global limit on the result from mas_intersects SQL

### DIFF
--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -341,9 +341,9 @@ create or replace function mas_intersect_polygons(
           path_unhash(po_hash)
         )
           as file
-      from (select distinct(po_hash) as po_hash from (%1$s) u) hashes
+      from (select distinct(po_hash) as po_hash from (%1$s) u %3$s) hashes
 
-      $f$, qstr, bbox
+      $f$, qstr, bbox, limit_str
     );
 
     return str;


### PR DESCRIPTION
This PR adds a global limit on the result from the `mas_intersects` SQL. This further speeds up the limit query.