### PR TITLE
added global cache control for http response

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -178,7 +178,6 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 			conf.GetLayerDates(iLayer, *verbose)
 		}
 
-		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 		err := utils.ExecuteWriteTemplateFile(w, conf,
 			utils.DataDir+"/templates/WMS_GetCapabilities.tpl")
 		if err != nil {
@@ -584,7 +583,6 @@ func serveWCS(ctx context.Context, params utils.WCSParams, conf *utils.Config, r
 			newConf.Layers[i].Dates = []string{newConf.Layers[i].Dates[0], newConf.Layers[i].Dates[len(newConf.Layers[i].Dates)-1]}
 		}
 
-		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 		err := utils.ExecuteWriteTemplateFile(w, &newConf, utils.DataDir+"/templates/WCS_GetCapabilities.tpl")
 		if err != nil {
 			metricsCollector.Info.HTTPStatus = 500
@@ -1430,6 +1428,7 @@ func serveWPS(ctx context.Context, params utils.WPSParams, conf *utils.Config, r
 // owsHandler handles every request received on /ows
 func generalHandler(conf *utils.Config, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 	if *verbose {
 		Info.Printf("%s\n", r.URL.String())
 	}
@@ -1586,6 +1585,7 @@ func fileHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 	http.ServeFile(w, r, upath)
 }
 


### PR DESCRIPTION
This PR globally disables cache in HTTP response. For near-time services, responding data can frequently change. It is essentially to disable front-end cache to ensure data up-to-date.