### PR TITLE
disabled creation of public views

### DIFF
--- a/mas/db/shard.sql
+++ b/mas/db/shard.sql
@@ -663,6 +663,3 @@ create or replace function refresh_caches()
     return true;
   end
 $$;
-
--- Add this schema to the public views, for cross-project search
-select public.refresh_views();


### PR DESCRIPTION
This PR disables creation of public views. This is to facilitate parallel ingestion of data from different shards. One can always create the public views manually if needed.