### PR TITLE
worked around crs not found for proj_create() since proj 6.0.0

### DIFF
--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -85,11 +85,16 @@ create or replace function public.ST_SplitDatelineWGS84(polygon geometry)
   end
 $$;
 
-create or replace function ST_TryTransform(polygon geometry, srid integer)
+create or replace function ST_TryTransform(polygon geometry, in_srid integer)
   returns geometry language plpgsql immutable as $$
 
+  declare
+
+    proj4txt    text;
+
   begin
-    return ST_Transform(polygon, srid);
+    proj4txt := (select proj4text from spatial_ref_sys where srid = in_srid limit 1);
+    return ST_SetSRID(ST_Transform(polygon, proj4txt), in_srid);
   exception
     when others then
       return null;


### PR DESCRIPTION
This PR provides a workaround to an issue in `project_create()` since PROJ 6.0.0+. Essentially with PostGIS 3.0.0+ built against PROJ 6.0.0+, if the `srid` is custom instead of built-in `srid` registered in the `spatial_ref_sys` table, `ST_Transform()` with the `srid` integer argument will output `project_create: crs not found` error. 