### PR TITLE
added support for worker timeout

### DIFF
--- a/gdal-process/main.go
+++ b/gdal-process/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"net"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/nci/gsky/utils"
@@ -30,7 +32,7 @@ func sendOutput(out *pb.Result, conn net.Conn) error {
 	return nil
 }
 
-func dataHandler(conn net.Conn, debug bool) {
+func dataHandler(conn net.Conn, debug bool, timeout int) {
 	defer conn.Close()
 	out := &pb.Result{}
 
@@ -48,17 +50,36 @@ func dataHandler(conn net.Conn, debug bool) {
 		sendOutput(out, conn)
 	}
 
-	switch in.Operation {
-	case "warp":
-		out = gp.WarpRaster(in, debug)
-	case "drill":
-		out = gp.DrillDataset(in)
-	case "extent":
-		out = gp.ComputeReprojectExtent(in)
-	case "info":
-		out = gp.ExtractGDALInfo(in)
-	default:
-		out.Error = fmt.Sprintf("Unknown operation: %s", in.Operation)
+	if len(in.Path) == 0 {
+		return
+	}
+
+	done := make(chan bool, 1)
+	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+
+	go func() {
+		switch in.Operation {
+		case "warp":
+			out = gp.WarpRaster(in, debug)
+		case "drill":
+			out = gp.DrillDataset(in)
+		case "extent":
+			out = gp.ComputeReprojectExtent(in)
+		case "info":
+			out = gp.ExtractGDALInfo(in)
+		default:
+			out.Error = fmt.Sprintf("Unknown operation: %s", in.Operation)
+		}
+
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		timeoutCancel()
+	case <-timeoutCtx.Done():
+		log.Printf("%v timed out in %v seconds", in.Path, timeout)
+		os.Exit(2)
 	}
 
 	err = sendOutput(out, conn)
@@ -78,6 +99,7 @@ func init() {
 func main() {
 	debug := flag.Bool("debug", false, "verbose logging")
 	sock := flag.String("sock", "", "unix socket path")
+	timeout := flag.Int("timeout", 120, "timeout in seconds")
 	flag.Parse()
 
 	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: *sock, Net: "unix"})
@@ -96,6 +118,6 @@ func main() {
 			return
 		}
 
-		dataHandler(conn, *debug)
+		dataHandler(conn, *debug, *timeout)
 	}
 }


### PR DESCRIPTION
This PR adds support for timing out the worker gdal-processes. This is to address https://github.com/nci/gsky/issues/378