### PR TITLE
added support for rescaling raster size

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -1397,6 +1397,8 @@ func serveWPS(ctx context.Context, params utils.WPSParams, conf *utils.Config, r
 				EndTime:          endDateTime,
 				ClipUpper:        clipUpper,
 				ClipLower:        clipLower,
+				RasterXSize:      dataSource.RasterXSize,
+				RasterYSize:      dataSource.RasterYSize,
 				MetricsCollector: metricsCollector,
 			}
 

--- a/processor/date_splitter.go
+++ b/processor/date_splitter.go
@@ -21,7 +21,7 @@ func (ts *TimeSplitter) Run() {
 	for geoReq := range ts.In {
 		if ts.YearStep > 0 {
 			for t := geoReq.StartTime; t.Before(geoReq.EndTime); t = t.AddDate(ts.YearStep, 0, 0) {
-				ts.Out <- &GeoDrillRequest{geoReq.Geometry, geoReq.CRS, geoReq.Collection, geoReq.NameSpaces, geoReq.BandExpr, geoReq.Mask, "", t, t.AddDate(ts.YearStep, 0, 0), geoReq.ClipUpper, geoReq.ClipLower, geoReq.MetricsCollector}
+				ts.Out <- &GeoDrillRequest{geoReq.Geometry, geoReq.CRS, geoReq.Collection, geoReq.NameSpaces, geoReq.BandExpr, geoReq.Mask, "", t, t.AddDate(ts.YearStep, 0, 0), geoReq.ClipUpper, geoReq.ClipLower, geoReq.RasterXSize, geoReq.RasterYSize, geoReq.MetricsCollector}
 			}
 		} else {
 			ts.Out <- geoReq

--- a/processor/drill_indexer.go
+++ b/processor/drill_indexer.go
@@ -243,11 +243,13 @@ func (p *DrillIndexer) Run(verbose bool) {
 					for _, dg := range dataGrans {
 
 						type GranuleInfo struct {
-							Data  *GeoDrillGranule
-							Masks []*GeoDrillGranule
+							RasterXSize float64
+							RasterYSize float64
+							Data        *GeoDrillGranule
+							Masks       []*GeoDrillGranule
 						}
 
-						granInfo := &GranuleInfo{Data: dg}
+						granInfo := &GranuleInfo{RasterXSize: geoReq.RasterXSize, RasterYSize: geoReq.RasterYSize, Data: dg}
 						for _, mg := range maskGrans {
 							granInfo.Masks = append(granInfo.Masks, mg)
 						}

--- a/processor/drill_types.go
+++ b/processor/drill_types.go
@@ -21,6 +21,8 @@ type GeoDrillRequest struct {
 	EndTime          time.Time
 	ClipUpper        float32
 	ClipLower        float32
+	RasterXSize      float64
+	RasterYSize      float64
 	MetricsCollector *metrics.MetricsCollector
 }
 

--- a/templates/WPS_VRTs/masks_example.vrt
+++ b/templates/WPS_VRTs/masks_example.vrt
@@ -1,4 +1,4 @@
-<VRTDataset>
+<VRTDataset rasterXSize="{{ .RasterXSize }}" rasterYSize="{{ .RasterYSize }}">
     <VRTRasterBand band="1" subClass="VRTDerivedRasterBand">
         <PixelFunctionType>apply_masks</PixelFunctionType>
         <PixelFunctionLanguage>python</PixelFunctionLanguage>

--- a/utils/config.go
+++ b/utils/config.go
@@ -178,6 +178,8 @@ type Layer struct {
 	MasQueryHint                 string       `json:"mas_query_hint"`
 	SRSCf                        int          `json:"srs_cf"`
 	Visibility                   string       `json:"visibility"`
+	RasterXSize                  float64      `json:"raster_x_size"`
+	RasterYSize                  float64      `json:"raster_y_size"`
 }
 
 // Process contains all the details that a WPS needs


### PR DESCRIPTION
This PR adds support for rescaling `rasterXSize` and `rasterYSize`. This is useful when computing WPS statistics in downsampled images.