### PR TITLE
fixed projection skewness issue in WMS

### DIFF
--- a/utils/wms.go
+++ b/utils/wms.go
@@ -488,7 +488,11 @@ func GetCanonicalBbox(srs string, bbox []float64) ([]float64, error) {
 	srs = strings.ToUpper(strings.TrimSpace(srs))
 	dst := "EPSG:3857"
 	if srs == dst {
-		return bbox, nil
+		box := make([]float64, len(bbox))
+		for i := 0; i < len(bbox); i++ {
+			box[i] = bbox[i]
+		}
+		return box, nil
 	}
 
 	var opts []*C.char


### PR DESCRIPTION
This PR fixes project skewness issue in WMS. The root cause of this issue was unintended modification of the input values of `geoReq.BBox`.