### PR TITLE
added support for incremental updates on MAS shards

### DIFF
--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -271,62 +271,49 @@ create or replace function mas_intersect_polygons(
 
     end if;
 
-    for rec in select ps_srid as srid from polygon_srids loop
-
-      parts := array_append(parts, format($f$
+    qstr := format($f$
+      (
+      select
+        po_hash
+      from
+        polygons
+      left join geometries
+          on true
+      inner join paths
+          on po_hash = pa_hash
+      where
         (
-        select
-          po_hash
-        from
-          polygons
-        inner join
-          geometries
-            on ge_srid = %1$s
-        inner join paths
-            on po_hash = pa_hash
-        where
-          st_srid(po_polygon) = %1$s
+          ST_Intersects(po_polygon, ge_geom)
+          -- Lossy transform gemoetry may have become a linestring if any points could not be transformed
+          or ST_Crosses(po_polygon, ge_geom)
+        )
 
-          and (
-            ST_Intersects(po_polygon, ge_geom)
-            -- Lossy transform gemoetry may have become a linestring if any points could not be transformed
-            or ST_Crosses(po_polygon, ge_geom)
+        and (
+          -- no times
+          %1$L::timestamptz is null
+
+          -- %1$L::timestamptz only
+          or (%1$L::timestamptz is not null and %2$L::timestamptz is null
+            and %1$L::timestamptz between po_min_stamp and po_max_stamp
+            and %1$L::timestamptz = any(po_stamps)
           )
 
-          and (
-            -- no times
-            %2$L::timestamptz is null
-
-            -- %2$L::timestamptz only
-            or (%2$L::timestamptz is not null and %3$L::timestamptz is null
-              and %2$L::timestamptz between po_min_stamp and po_max_stamp
-              and %2$L::timestamptz = any(po_stamps)
-            )
-
-            -- %2$L::timestamptz and %3$L::timestamptz range overlaps stamps
-            or (%2$L::timestamptz is not null and %3$L::timestamptz is not null
-              and (%2$L::timestamptz - interval '1 second', %3$L::timestamptz + interval '1 second') overlaps (po_min_stamp, po_max_stamp)
-            )
+          -- %1$L::timestamptz and %2$L::timestamptz range overlaps stamps
+          or (%1$L::timestamptz is not null and %2$L::timestamptz is not null
+            and (%1$L::timestamptz - interval '1 second', %2$L::timestamptz + interval '1 second') overlaps (po_min_stamp, po_max_stamp)
           )
-          and (%4$L is null
-            or po_name = any(%4$L)
-          )
-          and (%5$L is null
-            or po_pixel_x::bigint = %5$L::bigint
-          )
-          and path_hash(%6$L) = any(pa_parents)
-          %7$s )
+        )
+        and (%3$L is null
+          or po_name = any(%3$L)
+        )
+        and (%4$L is null
+          or po_pixel_x::bigint = %4$L::bigint
+        )
+        and path_hash(%5$L) = any(pa_parents)
+        %6$s )
 
-        $f$, rec.srid, time_a, time_b, namespaces, resolution, gpath, limit_str
+      $f$, time_a, time_b, namespaces, resolution, gpath, limit_str
 
-      ));
-
-    end loop;
-
-    -- for empty shards
-    qstr := coalesce(
-      nullif(array_to_string(parts, ' union '), ''),
-      'select null::uuid as po_hash limit 0'
     );
 
     str := format($f$
@@ -334,12 +321,8 @@ create or replace function mas_intersect_polygons(
       with
       geometries as (
         select
-          ps_srid
-            as ge_srid,
-          ST_ConvexHull(ST_LossyTransform(%2$L, ps_srid))
+          ST_ConvexHull(ST_LossyTransform(%2$L, 4326))
             as ge_geom
-        from
-          polygon_srids
       )
       select
         distinct(
@@ -671,7 +654,7 @@ create or replace function mas_spatial_temporal_extents(
       );
     end if;
 
-    proj4txt := (select proj4text from spatial_ref_sys where auth_srid = 3857 limit 1);
+    proj4txt := (select proj4text from spatial_ref_sys where srid = 3857 limit 1);
     result := (select
       jsonb_build_object(
         'xmin',

--- a/mas/db/ingest.sh
+++ b/mas/db/ingest.sh
@@ -3,4 +3,4 @@
 shard=$1
 
 iconv -f ISO-8859-1 -t UTF-8 | sort | uniq | psql -v ON_ERROR_STOP=1 -A -t -q -d mas \
-  -c "set search_path to ${shard}; copy ingest from stdin with (format 'csv', delimiter E'\\t', quote E'\\b');" >/dev/null
+  -c "set search_path to ${shard},public; copy ingest from stdin with (format 'csv', delimiter E'\\t', quote E'\\b');" >/dev/null

--- a/mas/db/ingest_pipeline.sh
+++ b/mas/db/ingest_pipeline.sh
@@ -125,5 +125,3 @@ do
 		(cd "$here" && zcat "${abs_filepath}" | sed $filters | bash shard_ingest.sh "${shard}")
 	fi
 done
-
-(cd "$here" && bash shard_refresh.sh "${shard}")

--- a/mas/db/ingest_pipeline.sh
+++ b/mas/db/ingest_pipeline.sh
@@ -120,8 +120,10 @@ do
 
 	if [ -z "$filters" ]
 	then
-		(cd "$here" && zcat "${abs_filepath}" | bash shard_ingest.sh "${shard}")
+		time (cd "$here" && zcat "${abs_filepath}" | bash shard_ingest.sh "${shard}")
 	else
-		(cd "$here" && zcat "${abs_filepath}" | sed $filters | bash shard_ingest.sh "${shard}")
+		time (cd "$here" && zcat "${abs_filepath}" | sed $filters | bash shard_ingest.sh "${shard}")
 	fi
 done
+
+time (cd "$here" && bash shard_refresh.sh "${shard}")

--- a/mas/db/schema.sql
+++ b/mas/db/schema.sql
@@ -60,6 +60,8 @@ create index srsi_auth_srid
 create index srsi_proj4text
   on spatial_ref_sys (proj4text);
 
+analyze spatial_ref_sys;
+
 -- Postgres has no built-in operators for indexing UUID using GIN
 create operator class _uuid_ops default
   for type _uuid using gin as

--- a/mas/db/schema.sql
+++ b/mas/db/schema.sql
@@ -54,6 +54,12 @@ set client_min_messages to warning;
 create extension postgis;
 grant all on spatial_ref_sys to mas;
 
+create index srsi_auth_srid
+  on spatial_ref_sys (auth_srid);
+
+create index srsi_proj4text
+  on spatial_ref_sys (proj4text);
+
 -- Postgres has no built-in operators for indexing UUID using GIN
 create operator class _uuid_ops default
   for type _uuid using gin as

--- a/mas/db/shard.sql
+++ b/mas/db/shard.sql
@@ -56,6 +56,17 @@ create function ingest_line()
       md_json jsonb not null
     );
 
+    create temporary table if not exists mypolygons (
+      po_hash uuid,
+      po_stamps timestamptz[],
+      po_min_stamp timestamptz,
+      po_max_stamp timestamptz,
+      po_name text,
+      po_pixel_x numeric,
+      po_pixel_y numeric,
+      po_polygon public.geometry
+    );
+
     set client_min_messages to warning;
 
     insert into mymetadata (
@@ -120,23 +131,13 @@ create trigger ingest before insert on ingest
 drop function if exists ingested_lines();
 create function ingested_lines()
   returns trigger language plpgsql as $$
+  declare
+
+    rec record;
+    proj4txt text;
+    trans_srid integer;
 
   begin
-
-    -- Create parent directories records if necessary
-
-    insert into mypaths
-      select
-        md5(path)::uuid,
-        now(),
-        'directory',
-        path
-      from (
-        select distinct(public.parent_paths(pa_path)) as path from mypaths
-      ) t
-    on conflict (pa_hash)
-      do nothing
-    ;
 
     update mypaths set pa_parents = (
       select
@@ -145,16 +146,125 @@ create function ingested_lines()
         public.parent_paths(pa_path) t
     );
 
-    -- Serialize the final session -> tables write to avoid deadlocks.
-    -- Doesn't appear to affect ingest batch concurrency much...
-    lock table paths in exclusive mode;
-
     insert into paths
       select * from mypaths
     on conflict (pa_hash)
       do update set
         pa_ingested = excluded.pa_ingested
     ;
+
+    drop table mypaths;
+
+    insert into public.nci_spatial_ref_sys (auth_name, srtext, proj4text)
+      select
+        'NCI',
+        b.srtext,
+        b.proj4text
+      from (
+        select
+          trim(geo#>>'{proj_wkt}')
+            as srtext,
+          trim(geo#>>'{proj4}')
+            as proj4text
+        from (
+          select
+            jsonb_array_elements(md_json->'geo_metadata')
+              as geo
+          from
+            mymetadata
+          where
+            md_type = 'gdal'
+            and jsonb_typeof(md_json->'geo_metadata') = 'array'
+        ) a
+        group by srtext, proj4text
+      ) b
+      left join public.spatial_ref_sys s1
+        on b.srtext = s1.srtext
+        and b.proj4text = s1.proj4text
+      left join public.nci_spatial_ref_sys s2
+        on b.srtext = s2.srtext
+        and b.proj4text = s2.proj4text
+      where
+        trim(b.srtext) <> ''
+        and trim(b.proj4text) <> ''
+        and s1.srtext is null
+        and s2.srtext is null
+    ;
+
+    insert into public.spatial_ref_sys (srid, auth_name, auth_srid, srtext, proj4text)
+      select srid, auth_name, srid, srtext, proj4text from public.nci_spatial_ref_sys
+    on conflict (srid) do nothing;
+
+    proj4txt := (select proj4text from public.spatial_ref_sys where auth_srid = 4326 and trim(proj4text) <> '' limit 1);
+    trans_srid := (select srid from public.spatial_ref_sys where auth_srid = 4326 and trim(proj4text) <> '' limit 1);
+
+    insert into mypolygons
+      select
+        hash
+          as po_hash,
+        array(select jsonb_array_elements_text(stamps))::timestamptz[]
+          as po_stamps,
+        (select min(t) from unnest(array(select jsonb_array_elements_text(stamps))::timestamptz[]) t)
+          as po_min_stamp,
+        (select max(t) from unnest(array(select jsonb_array_elements_text(stamps))::timestamptz[]) t)
+          as po_max_stamp,
+        variable
+          as po_name,
+        (geotransform->>1)::numeric
+          as po_pixel_x,
+        (geotransform->>5)::numeric
+          as po_pixel_y,
+        public.st_setsrid(public.st_transform(public.st_geomfromtext(polygon, srid), proj4txt), trans_srid)
+          as po_polygon
+      from (
+        select
+          hash,
+          trim(geo#>>'{polygon}')
+            as polygon,
+          trim(geo#>>'{proj_wkt}')
+            as srtext,
+          trim(geo#>>'{proj4}')
+            as proj4text,
+          regexp_replace(trim(geo#>>'{namespace}'), '[^a-zA-Z0-9_]', '_', 'g')
+            as variable,
+          geo#>'{timestamps}'
+            as stamps,
+          geo#>'{geotransform}'
+            as geotransform
+        from (
+          select
+            md_hash
+              as hash,
+            jsonb_array_elements(md_json->'geo_metadata')
+              as geo
+          from mymetadata
+          where
+          md_type = 'gdal'
+          and jsonb_typeof(md_json->'geo_metadata') = 'array'
+        ) a
+      ) b
+      join public.spatial_ref_sys s
+        on b.srtext = s.srtext
+        and b.proj4text = s.proj4text
+        and trim(b.srtext) <> ''
+        and trim(b.proj4text) <> ''
+        and trim(b.polygon) <> ''
+    ;
+
+    insert into polygons select * from mypolygons
+      on conflict (po_hash, po_name)
+      do update set
+        po_hash = excluded.po_hash,
+        po_stamps = excluded.po_stamps,
+        po_min_stamp = excluded.po_min_stamp,
+        po_max_stamp = excluded.po_max_stamp,
+        po_name = excluded.po_name,
+        po_pixel_x = excluded.po_pixel_x,
+        po_pixel_y = excluded.po_pixel_y,
+        po_polygon = excluded.po_polygon
+    ;
+
+    drop table mypolygons;
 
     insert into metadata select * from mymetadata
       on conflict (md_hash, md_type)
@@ -163,8 +273,9 @@ create function ingested_lines()
         md_json = excluded.md_json
     ;
 
-    drop table mypaths;
     drop table mymetadata;
+
+    perform refresh_caches();
 
     return null;
   end
@@ -352,59 +463,20 @@ create unique index dii_hash
   on directories (di_hash);
 
 -- View of polygon metadata supplied by GDAL crawler, for GSKY
-drop materialized view if exists polygons cascade;
-create materialized view polygons as
-  select
-    hash
-      as po_hash,
-    array(select jsonb_array_elements_text(stamps))::timestamptz[]
-      as po_stamps,
-    (select min(t) from unnest(array(select jsonb_array_elements_text(stamps))::timestamptz[]) t)
-      as po_min_stamp,
-    (select max(t) from unnest(array(select jsonb_array_elements_text(stamps))::timestamptz[]) t)
-      as po_max_stamp,
-    variable
-      as po_name,
-    (geotransform->>1)::numeric
-      as po_pixel_x,
-    (geotransform->>5)::numeric
-      as po_pixel_y,
-    public.st_geomfromtext(polygon, srid)
-      as po_polygon
-  from (
-    select
-      hash,
-      trim(geo#>>'{polygon}')
-        as polygon,
-      trim(geo#>>'{proj_wkt}')
-        as srtext,
-      trim(geo#>>'{proj4}')
-        as proj4text,
-      regexp_replace(trim(geo#>>'{namespace}'), '[^a-zA-Z0-9_]', '_', 'g')
-        as variable,
-      geo#>'{timestamps}'
-        as stamps,
-      geo#>'{geotransform}'
-        as geotransform
-    from (
-      select
-        md_hash
-          as hash,
-        jsonb_array_elements(md_json->'geo_metadata')
-          as geo
-      from metadata
-      where
-      md_type = 'gdal'
-      and jsonb_typeof(md_json->'geo_metadata') = 'array'
-    ) a
-  ) b
-  join public.spatial_ref_sys s
-    on b.srtext = s.srtext
-    and b.proj4text = s.proj4text
-;
+drop table if exists polygons cascade;
+create table polygons (
+  po_hash uuid,
+  po_stamps timestamptz[],
+  po_min_stamp timestamptz,
+  po_max_stamp timestamptz,
+  po_name text,
+  po_pixel_x numeric,
+  po_pixel_y numeric,
+  po_polygon public.geometry
+);
 
-create index poi_hash
-  on polygons (po_hash);
+create unique index poi_pk
+  on polygons (po_hash, po_name);
 
 create index poi_stamp
   on polygons (po_min_stamp, po_max_stamp);
@@ -412,17 +484,8 @@ create index poi_stamp
 create index poi_stamps
   on polygons using gin (po_stamps);
 
-create index poi_name
-  on polygons (po_name);
-
--- A list of SRID values for the schema, used for faster intersections
-drop materialized view if exists polygon_srids cascade;
-create materialized view polygon_srids as
-  select
-    distinct(public.st_srid(po_polygon))
-      as ps_srid
-    from
-      polygons;
+create index poi_polygon
+  on polygons using gist (po_polygon);
 
 -- Extracted NetCDF headers
 drop view if exists netcdf cascade;
@@ -562,85 +625,6 @@ create function refresh_views()
 
     raise notice 'refresh directories';
     refresh materialized view directories;
-
-    return true;
-  end
-$$;
-
-create or replace function refresh_polygons()
-  returns boolean language plpgsql as $$
-
-  declare
-
-    rec record;
-
-  begin
-
-    insert into public.nci_spatial_ref_sys (auth_name, srtext, proj4text)
-      select
-        'NCI',
-        b.srtext,
-        b.proj4text
-      from (
-        select
-          trim(geo#>>'{proj_wkt}')
-            as srtext,
-          trim(geo#>>'{proj4}')
-            as proj4text
-        from (
-          select
-            jsonb_array_elements(md_json->'geo_metadata')
-              as geo
-          from
-            metadata
-          where
-            md_type = 'gdal'
-            and jsonb_typeof(md_json->'geo_metadata') = 'array'
-        ) a
-        group by srtext, proj4text
-      ) b
-      left join public.spatial_ref_sys s1
-        on b.srtext = s1.srtext
-        and b.proj4text = s1.proj4text
-      left join public.nci_spatial_ref_sys s2
-        on b.srtext = s2.srtext
-        and b.proj4text = s2.proj4text
-      where
-        s1.srtext is null
-        and s2.srtext is null
-    ;
-
-    insert into public.spatial_ref_sys (srid, auth_name, auth_srid, srtext, proj4text)
-      select srid, auth_name, srid, srtext, proj4text from public.nci_spatial_ref_sys
-    on conflict (srid) do nothing;
-
-    for rec in select ci.relname from pg_index i, pg_class ci, pg_class ct where i.indexrelid = ci.oid and i.indrelid = ct.oid and ct.relname = 'polygons' and ci.relname like 'poi\_polygon\_%' loop
-
-      raise notice 'drop index %', rec.relname;
-
-      execute format($f$
-        drop index if exists %1$s
-          $f$, rec.relname
-      );
-
-    end loop;
-
-    raise notice 'refresh polygons';
-    refresh materialized view polygons;
-
-    raise notice 'refresh polygon_srids';
-    refresh materialized view polygon_srids;
-
-    for rec in select ps_srid as srid from polygon_srids loop
-
-      raise notice 'srid create index poi_polygon_%', rec.srid;
-
-      execute format($f$
-        create index if not exists poi_polygon_%1$s on polygons using gist (po_polygon) where public.st_srid(po_polygon) = %1$s
-          $f$, rec.srid
-      );
-
-    end loop;
 
     return true;
   end

--- a/mas/db/shard_refresh.sh
+++ b/mas/db/shard_refresh.sh
@@ -1,17 +1,14 @@
 #!/bin/bash
 
-## This file is now only for compatibility of old ingestion pipeline code
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+shard=$1
 
-#here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-#shard=$1
+(cd "$here" && psql -v ON_ERROR_STOP=1 -A -t -q -d mas <<EOD
 
-#(cd "$here" && psql -v ON_ERROR_STOP=1 -A -t -q -d mas <<EOD
+set role mas;
+set search_path to ${shard};
 
-#set role mas;
-#set search_path to ${shard};
+select analyze_shard();
 
-#select refresh_polygons();
-#select refresh_caches();
-
-#EOD
-#)
+EOD
+)

--- a/mas/db/shard_refresh.sh
+++ b/mas/db/shard_refresh.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 
-here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-shard=$1
+## This file is now only for compatibility of old ingestion pipeline code
 
-(cd "$here" && psql -v ON_ERROR_STOP=1 -A -t -q -d mas <<EOD
+#here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#shard=$1
 
-set role mas;
-set search_path to ${shard};
+#(cd "$here" && psql -v ON_ERROR_STOP=1 -A -t -q -d mas <<EOD
 
-select refresh_polygons();
-select refresh_caches();
+#set role mas;
+#set search_path to ${shard};
 
-EOD
-)
+#select refresh_polygons();
+#select refresh_caches();
+
+#EOD
+#)


### PR DESCRIPTION
This PR adds support for incremental updates on MAS shards. Previously ingesting crawl results into MAS requires a refresh of materialised views, which is expensive for large datasets. This PR replaces the materialised views by tables, which enables incremental updates on them.