### PR TITLE
query auth_srid instead of srid for proj4text from spatial_ref_sys

### DIFF
--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -654,7 +654,7 @@ create or replace function mas_spatial_temporal_extents(
       );
     end if;
 
-    proj4txt := (select proj4text from spatial_ref_sys where srid = 3857 limit 1);
+    proj4txt := (select proj4text from spatial_ref_sys where auth_srid = 3857 limit 1);
     result := (select
       jsonb_build_object(
         'xmin',


### PR DESCRIPTION
This PR queries `auth_srid` instead of `srid` for `proj4text` from `spatial_ref_sys`. This is because `auth_srid` and `srid` do not always have correspondence.