### PR TITLE
consistent token for querying timestamps cache

### DIFF
--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -557,14 +557,11 @@ create or replace function mas_timestamps(
     query_hash := md5(concat(gpath, coalesce(time_a::text, 'null'),
       coalesce(time_b::text, 'null'), array_to_string(namespace, ',', 'null')));
 
-    if token is not null then
-      select jsonb_build_object('timestamps', '[]'::jsonb, 'token', token) into result from timestamps_cache where query_id = query_hash and query_token = token;
-      if result is not null then
-        return result;
-      end if;
+    if token is not null and token = query_hash then
+      return jsonb_build_object('timestamps', '[]'::jsonb, 'token', query_hash);
     end if;
 
-    select timestamps || jsonb_build_object('token', query_token) into result from timestamps_cache where query_id = query_hash;
+    select timestamps || jsonb_build_object('token', query_hash) into result from timestamps_cache where query_id = query_hash;
     if result is not null then
       return result;
     end if;
@@ -574,7 +571,6 @@ create or replace function mas_timestamps(
       time_b := (select now());
     end if;
 
-    token := extract(epoch from now())::text;
     result := jsonb_build_object('timestamps', coalesce((
 
       -- We perform two-stage time range filtering here:
@@ -606,9 +602,9 @@ create or replace function mas_timestamps(
       where (time_a is null or po_stamps >= time_a)
       and po_stamps <= time_b
 
-     ), '[]'::jsonb), 'token', token);
+     ), '[]'::jsonb), 'token', query_hash);
 
-     insert into timestamps_cache (query_id, timestamps, query_token) values (query_hash, result, token)
+     insert into timestamps_cache (query_id, timestamps) values (query_hash, result)
      on conflict (query_id) do nothing;
 
      perform mas_reset();

--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -558,7 +558,10 @@ create or replace function mas_timestamps(
       coalesce(time_b::text, 'null'), array_to_string(namespace, ',', 'null')));
 
     if token is not null and token = query_hash then
-      return jsonb_build_object('timestamps', '[]'::jsonb, 'token', query_hash);
+      select jsonb_build_object('timestamps', '[]'::jsonb, 'token', query_hash) into result from timestamps_cache where query_id = query_hash;
+      if result is not null then
+        return result;
+      end if;
     end if;
 
     select timestamps || jsonb_build_object('token', query_hash) into result from timestamps_cache where query_id = query_hash;

--- a/mas/db/shard.sql
+++ b/mas/db/shard.sql
@@ -594,8 +594,7 @@ drop table if exists timestamps_cache cascade;
 -- cache for timestamps
 create unlogged table timestamps_cache (
   query_id text primary key,
-  timestamps jsonb not null,
-  query_token text
+  timestamps jsonb not null
 );
 
 create or replace function refresh_caches()


### PR DESCRIPTION
This PR makes timestamps query token consistent across queries and nodes. This is important for MAS with load balancer.