### PR TITLE
not treating empty input to drill_merge an error

### DIFF
--- a/processor/drill_merger.go
+++ b/processor/drill_merger.go
@@ -65,7 +65,6 @@ func (dm *DrillMerger) Run(suffix string, namespaces []string, templateFileName 
 		}
 	}
 	if len(results) == 0 {
-		dm.sendError(fmt.Errorf("Drill Merger: no result"))
 		return
 	}
 


### PR DESCRIPTION
This PR does not treat empty input to drill_merge an error.