### PR TITLE
taking nodata into account for mask bands

### DIFF
--- a/templates/WPS_VRTs/masks_example.vrt
+++ b/templates/WPS_VRTs/masks_example.vrt
@@ -6,8 +6,9 @@
 def apply_masks(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize,
     raster_ysize, buf_radius, gt, **kwargs):
   out_ar[:] = in_ar[0]
-  masks = (in_ar[1] != 1) | (in_ar[2] != 1)
-  out_ar[masks] = -999
+  nodata = -999
+  masks = ((in_ar[1] != nodata) & (in_ar[1] != 1)) | ((in_ar[2] != nodata) & (in_ar[2] != 1))
+  out_ar[masks] = nodata
         ]]>
         </PixelFunctionCode>
         <SimpleSource metadata-template="1">


### PR DESCRIPTION
This PR takes nodata into account for mask bands in the VRT example.