### PR TITLE
made use of empty struct for key-only hash map lookup

### DIFF
--- a/dap.go
+++ b/dap.go
@@ -137,7 +137,7 @@ func dapToWcs(ce *utils.DapConstraints, conf *utils.Config) (*utils.WCSParams, e
 	}
 
 	if len(varExpr) == 0 {
-		var specialVars = map[string]bool{"x": true, "y": true}
+		var specialVars = map[string]struct{}{"x": struct{}{}, "y": struct{}{}}
 		foundOthers := false
 		for _, axis := range wcsParams.Axes {
 			if _, found := specialVars[axis.Name]; !found {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -61,7 +61,7 @@ type MetricsCollector struct {
 	logger Logger
 }
 
-var reservedQueryParams = map[string]bool{"bbox": true, "coverage": true, "crs": true, "dptol": true, "height": true, "identifier": true, "identitytol": true, "layer": true, "layers": true, "limit": true, "namespace": true, "nseg": true, "request": true, "service": true, "srs": true, "styles": true, "time": true, "until": true, "version": true, "width": true, "wkt": true}
+var reservedQueryParams = map[string]struct{}{"bbox": struct{}{}, "coverage": struct{}{}, "crs": struct{}{}, "dptol": struct{}{}, "height": struct{}{}, "identifier": struct{}{}, "identitytol": struct{}{}, "layer": struct{}{}, "layers": struct{}{}, "limit": struct{}{}, "namespace": struct{}{}, "nseg": struct{}{}, "request": struct{}{}, "service": struct{}{}, "srs": struct{}{}, "styles": struct{}{}, "time": struct{}{}, "until": struct{}{}, "version": struct{}{}, "width": struct{}{}, "wkt": struct{}{}}
 
 func NewMetricsCollector(logger Logger) *MetricsCollector {
 	return &MetricsCollector{

--- a/processor/drill_indexer.go
+++ b/processor/drill_indexer.go
@@ -192,7 +192,7 @@ func (p *DrillIndexer) Run(verbose bool) {
 		}
 
 		isFirst := true
-		dedupGranules := make(map[string]bool)
+		dedupGranules := make(map[string]struct{})
 		for res := range tiledRes {
 			p.processDatasets(res, geoReq, template, dedupGranules, verbose, &isFirst)
 			if p.checkCancellation() {
@@ -211,7 +211,7 @@ func (p *DrillIndexer) Run(verbose bool) {
 	}
 }
 
-func (p *DrillIndexer) processDatasets(res *TiledResponse, geoReq *GeoDrillRequest, template *jet.Template, dedupGranules map[string]bool, verbose bool, isFirst *bool) {
+func (p *DrillIndexer) processDatasets(res *TiledResponse, geoReq *GeoDrillRequest, template *jet.Template, dedupGranules map[string]struct{}, verbose bool, isFirst *bool) {
 	metadata := res.Metadata
 	switch len(metadata.GDALDatasets) {
 	case 0:
@@ -223,7 +223,7 @@ func (p *DrillIndexer) processDatasets(res *TiledResponse, geoReq *GeoDrillReque
 			if _, found := dedupGranules[ds.DSName+ds.NameSpace]; found {
 				continue
 			}
-			dedupGranules[ds.DSName+ds.NameSpace] = true
+			dedupGranules[ds.DSName+ds.NameSpace] = struct{}{}
 
 			grans = append(grans, &GeoDrillGranule{ds.DSName, ds.NameSpace, ds.ArrayType, ds.TimeStamps, geoReq.Geometry, geoReq.CRS, "", ds.Means, ds.SampleCounts, ds.NoData, p.Approx, geoReq.ClipUpper, geoReq.ClipLower, geoReq.RasterXSize, geoReq.RasterYSize, geoReq.GrpcConcLimit, geoReq.MetricsCollector})
 			effectiveDatasets = append(effectiveDatasets, ds)
@@ -256,9 +256,9 @@ func (p *DrillIndexer) processDatasets(res *TiledResponse, geoReq *GeoDrillReque
 				granMaskGroups[key] = append(granMaskGroups[key], grans[ids])
 			}
 
-			dataNSLookup := make(map[string]bool)
+			dataNSLookup := make(map[string]struct{})
 			for _, ns := range geoReq.NameSpaces {
-				dataNSLookup[ns] = true
+				dataNSLookup[ns] = struct{}{}
 			}
 
 			maskNSLookup := make(map[string]int)

--- a/processor/feature_info.go
+++ b/processor/feature_info.go
@@ -351,7 +351,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 	}
 
 	var pixelFiles []*GeoTileGranule
-	timestampLookup := make(map[time.Time]bool)
+	timestampLookup := make(map[time.Time]struct{})
 	for _, geo := range indexerOut {
 		if geo.NameSpace == utils.EmptyTileNS {
 			continue
@@ -363,7 +363,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 			continue
 		}
 
-		timestampLookup[normalizedTm] = true
+		timestampLookup[normalizedTm] = struct{}{}
 		pixelFiles = append(pixelFiles, geo)
 	}
 
@@ -390,7 +390,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 		return ftInfo, nil
 	}
 
-	fileDedup := make(map[string]bool)
+	fileDedup := make(map[string]struct{})
 	for i, ds := range pixelFiles {
 		dsFile := ds.RawPath
 		if len(dsFile) == 0 {
@@ -401,7 +401,7 @@ func getRaster(ctx context.Context, params utils.WMSParams, conf *utils.Config, 
 		if found {
 			continue
 		}
-		fileDedup[dsFile] = true
+		fileDedup[dsFile] = struct{}{}
 
 		if strings.Index(dsFile, styleLayer.DataSource) >= 0 {
 			offset := 0

--- a/processor/tile_extent.go
+++ b/processor/tile_extent.go
@@ -26,7 +26,7 @@ func ComputeReprojectionExtent(ctx context.Context, geoReq *GeoTileRequest, masA
 
 	go indexer.Run(verbose)
 
-	fileLookup := make(map[string]bool)
+	fileLookup := make(map[string]struct{})
 	var indexGrans []*GeoTileGranule
 	for gran := range indexer.Out {
 		select {
@@ -36,7 +36,7 @@ func ComputeReprojectionExtent(ctx context.Context, geoReq *GeoTileRequest, masA
 			return -1, -1, ctx.Err()
 		default:
 			if _, found := fileLookup[gran.RawPath]; !found {
-				fileLookup[gran.RawPath] = true
+				fileLookup[gran.RawPath] = struct{}{}
 				indexGrans = append(indexGrans, gran)
 			}
 		}

--- a/processor/tile_grpc.go
+++ b/processor/tile_grpc.go
@@ -51,8 +51,8 @@ func (gi *GeoRasterGRPC) Run(varList []string, verbose bool) {
 	var g0 *GeoTileGranule
 	var grans []*GeoTileGranule
 	var nullGrans []*GeoTileGranule
-	availNamespaces := make(map[string]bool)
-	dedupGrans := make(map[string]bool)
+	availNamespaces := make(map[string]struct{})
+	dedupGrans := make(map[string]struct{})
 	var connPool []*grpc.ClientConn
 	var projWKT string
 	var cLimiter *ConcLimiter
@@ -78,11 +78,11 @@ func (gi *GeoRasterGRPC) Run(varList []string, verbose bool) {
 		if _, hasGran := dedupGrans[granKey]; hasGran {
 			continue
 		}
-		dedupGrans[granKey] = true
+		dedupGrans[granKey] = struct{}{}
 		grans = append(grans, inGran)
 
 		if _, found := availNamespaces[inGran.VarNameSpace]; !found {
-			availNamespaces[inGran.VarNameSpace] = true
+			availNamespaces[inGran.VarNameSpace] = struct{}{}
 		}
 
 		if iGran == 0 {

--- a/processor/tile_indexer.go
+++ b/processor/tile_indexer.go
@@ -340,7 +340,7 @@ func (p *TileIndexer) URLIndexGet(ctx context.Context, url string, geoReq *GeoTi
 		}
 		out <- &GeoTileGranule{ConfigPayLoad: ConfigPayLoad{NameSpaces: []string{utils.EmptyTileNS}, ScaleParams: geoReq.ScaleParams, Palette: geoReq.Palette}, Path: "NULL", NameSpace: utils.EmptyTileNS, RasterType: "Byte", TimeStamp: 0, BBox: geoReq.BBox, Height: geoReq.Height, Width: geoReq.Width, OffX: geoReq.OffX, OffY: geoReq.OffY, CRS: geoReq.CRS}
 	default:
-		axisParamsLookup := make(map[string]map[float64]bool)
+		axisParamsLookup := make(map[string]map[float64]struct{})
 		for _, ds := range metadata.GDALDatasets {
 			if len(ds.Axes) == 0 {
 				ds.Axes = append(ds.Axes, &DatasetAxis{Name: "time", Strides: []int{1}, Grid: "default"})
@@ -365,9 +365,9 @@ func (p *TileIndexer) URLIndexGet(ctx context.Context, url string, geoReq *GeoTi
 					var selErr error
 					if len(tileAxis.IdxSelectors) > 0 {
 						if _, found := axisParamsLookup[axis.Name]; !found {
-							axisParamsLookup[axis.Name] = make(map[float64]bool)
+							axisParamsLookup[axis.Name] = make(map[float64]struct{})
 							for _, val := range axis.Params {
-								axisParamsLookup[axis.Name][val] = true
+								axisParamsLookup[axis.Name][val] = struct{}{}
 							}
 						} else {
 							for _, val := range axis.Params {
@@ -592,7 +592,7 @@ func doSelectionByIndices(axis *DatasetAxis, tileAxis *GeoTileAxis) (bool, error
 		return false, fmt.Errorf("grid type must be 'enum' for index-based selections")
 	}
 
-	idxLookup := make(map[int]bool)
+	idxLookup := make(map[int]struct{})
 	for _, sel := range tileAxis.IdxSelectors {
 		if sel.IsAll {
 			axis.IntersectionIdx = make([]int, len(axis.Params))
@@ -618,7 +618,7 @@ func doSelectionByIndices(axis *DatasetAxis, tileAxis *GeoTileAxis) (bool, error
 				continue
 			}
 
-			idxLookup[idx] = true
+			idxLookup[idx] = struct{}{}
 			axis.IntersectionIdx = append(axis.IntersectionIdx, idx)
 			axis.IntersectionValues = append(axis.IntersectionValues, axis.Params[idx])
 			continue

--- a/utils/config.go
+++ b/utils/config.go
@@ -115,7 +115,7 @@ type Layer struct {
 	Overviews                    []Layer  `json:"overviews"`
 	InputLayers                  []Layer  `json:"input_layers"`
 	DisableServices              []string `json:"disable_services"`
-	DisableServicesMap           map[string]bool
+	DisableServicesMap           map[string]struct{}
 	DataSource                   string `json:"data_source"`
 	StartISODate                 string `json:"start_isodate"`
 	EndISODate                   string `json:"end_isodate"`
@@ -712,10 +712,10 @@ func (config *Config) processFusionTimestamps(i int, configMap map[string]*Confi
 	}
 	if len(inputLayers) > 0 {
 		var timestamps []string
-		tsLookup := make(map[string]bool)
+		tsLookup := make(map[string]struct{})
 		for _, dt := range config.Layers[i].Dates {
 			if _, found := tsLookup[dt]; !found {
-				tsLookup[dt] = true
+				tsLookup[dt] = struct{}{}
 				timestamps = append(timestamps, dt)
 			}
 		}
@@ -734,7 +734,7 @@ func (config *Config) processFusionTimestamps(i int, configMap map[string]*Confi
 			}
 			for _, dt := range layer.Dates {
 				if _, found := tsLookup[dt]; !found {
-					tsLookup[dt] = true
+					tsLookup[dt] = struct{}{}
 					timestamps = append(timestamps, dt)
 				}
 			}
@@ -998,7 +998,7 @@ func (config *Config) GetLayerDates(iLayer int, verbose bool) {
 
 func ParseBandExpressions(bands []string) (*BandExpressions, error) {
 	bandExpr := &BandExpressions{ExprText: bands}
-	varFound := make(map[string]bool)
+	varFound := make(map[string]struct{})
 	hasExprAll := false
 	for ib, bandRaw := range bands {
 		parts := strings.Split(bandRaw, "=")
@@ -1027,7 +1027,7 @@ func ParseBandExpressions(bands []string) (*BandExpressions, error) {
 		bandExpr.Expressions = append(bandExpr.Expressions, expr)
 
 		bandExpr.ExprVarRef = append(bandExpr.ExprVarRef, []string{})
-		bandVarFound := make(map[string]bool)
+		bandVarFound := make(map[string]struct{})
 		for _, token := range expr.Tokens() {
 			if token.Kind == goeval.VARIABLE {
 				varName, ok := token.Value.(string)
@@ -1036,12 +1036,12 @@ func ParseBandExpressions(bands []string) (*BandExpressions, error) {
 				}
 
 				if _, found := varFound[varName]; !found {
-					varFound[varName] = true
+					varFound[varName] = struct{}{}
 					bandExpr.VarList = append(bandExpr.VarList, varName)
 				}
 
 				if _, found := bandVarFound[varName]; !found {
-					bandVarFound[varName] = true
+					bandVarFound[varName] = struct{}{}
 					bandExpr.ExprVarRef[ib] = append(bandExpr.ExprVarRef[ib], varName)
 				}
 

--- a/utils/dap4_ce_parser.go
+++ b/utils/dap4_ce_parser.go
@@ -138,11 +138,11 @@ func ParseDap4ConstraintExpr(ceStr string) (*DapConstraints, error) {
 		return nil, err
 	}
 
-	varLookup := make(map[string]bool)
+	varLookup := make(map[string]struct{})
 	for _, vp := range ce.VarParams {
 		_, found := varLookup[vp.Name]
 		if !found {
-			varLookup[vp.Name] = true
+			varLookup[vp.Name] = struct{}{}
 		} else {
 			return nil, fmt.Errorf("duplicated constraint for variable: %v", vp.Name)
 		}

--- a/utils/dap4_encoders.go
+++ b/utils/dap4_encoders.go
@@ -227,10 +227,10 @@ func floatArrToBytes(arr []float64) []byte {
 }
 
 func getDimensions(dims []string) ([]string, []string, map[string][]float64, error) {
-	varLookup := make(map[string]bool)
+	varLookup := make(map[string]struct{})
 	varNames := make([]string, 0)
 
-	valsLookup := make(map[string]map[float64]bool)
+	valsLookup := make(map[string]map[float64]struct{})
 	axisVals := make(map[string][]float64)
 	axisNames := make([]string, 0)
 
@@ -245,7 +245,7 @@ func getDimensions(dims []string) ([]string, []string, map[string][]float64, err
 		varPart := parts[0]
 		if _, found := varLookup[varPart]; !found {
 			if varPart != EmptyTileNS {
-				varLookup[varPart] = true
+				varLookup[varPart] = struct{}{}
 				varName := varPart
 				if !varNameRegex.MatchString(varName) {
 					iVar++
@@ -269,7 +269,7 @@ func getDimensions(dims []string) ([]string, []string, map[string][]float64, err
 
 			axisName := kv[0]
 			if _, found := valsLookup[axisName]; !found {
-				valsLookup[axisName] = make(map[float64]bool)
+				valsLookup[axisName] = make(map[float64]struct{})
 				axisVals[axisName] = make([]float64, 0)
 				axisNames = append(axisNames, axisName)
 			}
@@ -285,7 +285,7 @@ func getDimensions(dims []string) ([]string, []string, map[string][]float64, err
 			}
 
 			if _, found := valsLookup[axisName][val]; !found {
-				valsLookup[axisName][val] = true
+				valsLookup[axisName][val] = struct{}{}
 				axisVals[axisName] = append(axisVals[axisName], val)
 			}
 

--- a/utils/url_parser.go
+++ b/utils/url_parser.go
@@ -71,10 +71,10 @@ func unescapeUrl(s string) (string, error) {
 }
 
 func ParseQuery(query string) (m url.Values, err error) {
-	specialKeyLookup := make(map[string]bool)
-	specialKeyLookup["rangesubset"] = true
-	specialKeyLookup["subset"] = true
-	specialKeyLookup["dap4.ce"] = true
+	specialKeyLookup := make(map[string]struct{})
+	specialKeyLookup["rangesubset"] = struct{}{}
+	specialKeyLookup["subset"] = struct{}{}
+	specialKeyLookup["dap4.ce"] = struct{}{}
 
 	m = make(url.Values)
 	for query != "" {

--- a/utils/wms.go
+++ b/utils/wms.go
@@ -469,10 +469,10 @@ func GetCurrentTimeStamp(timestamps []string) (*time.Time, error) {
 func CheckDisableServices(layer *Layer, service string) bool {
 	if len(layer.DisableServices) > 0 {
 		if layer.DisableServicesMap == nil {
-			layer.DisableServicesMap = make(map[string]bool)
+			layer.DisableServicesMap = make(map[string]struct{})
 			for _, srv := range layer.DisableServices {
 				srv = strings.ToLower(strings.TrimSpace(srv))
-				layer.DisableServicesMap[srv] = true
+				layer.DisableServicesMap[srv] = struct{}{}
 			}
 		}
 


### PR DESCRIPTION
This PR makes use of empty struct for key-only hash map lookup. This reduces memory footprint of these hash maps.