### PR TITLE
properly naming file id for posix crawler

### DIFF
--- a/crawl/extractor/types.go
+++ b/crawl/extractor/types.go
@@ -61,5 +61,5 @@ type PosixInfo struct {
 	Size     int64     `json:"size"`
 	MTime    time.Time `json:"mtime"`
 	CTime    time.Time `json:"ctime"`
-	ID       string    `json:"id"`
+	ID       string    `json:"file_id"`
 }


### PR DESCRIPTION
This PR names file id properly for the POSIX crawler.