### PR TITLE
adaptive netcdf cache size

### DIFF
--- a/libs/gdal/frmts/gsky_netcdf/netcdfdataset.cpp
+++ b/libs/gdal/frmts/gsky_netcdf/netcdfdataset.cpp
@@ -631,7 +631,7 @@ void netCDFRasterBand::SetBlockSize()
                   chunkSizeBytes *= chunksize[i];
                 }
 
-                if(cacheSize < chunkSizeBytes) {
+                if(cacheSize < chunkSizeBytes * 5) {
                   const size_t MAX_CACHE_SIZE = (size_t)4 * 1024 * 1024 * 1024;
                   size_t maxChunks = MAX_CACHE_SIZE / chunkSizeBytes;
                   if(maxChunks < 1) {


### PR DESCRIPTION
This PR adds adaptive netCDF cache size. This is essential to datasets with netCDF files using non-uniform chunk sizes.