### PR TITLE
added lock timeout

### DIFF
--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -162,6 +162,7 @@ create or replace function mas_reset()
   returns void language plpgsql as $$
   begin
     set work_mem to '32MB';
+    set lock_timeout to '10s';
     perform set_config('search_path', 'public', false);
   end
 $$;


### PR DESCRIPTION
This PR adds lock timeout on the PostgreSQL objects in the shard corresponding to the dataset during bulk ingestion.