### PR TITLE
made to use Ubuntu LTS base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10 
+FROM ubuntu:18.04
 MAINTAINER GSKY Developers <help@nci.org.au>
 
 RUN apt-get update \


### PR DESCRIPTION
This PR makes to use Ubuntu LTS base image for GSKY docker build.