### PR TITLE
configurable shard_ingest

### DIFF
--- a/mas/db/shard_ingest.sh
+++ b/mas/db/shard_ingest.sh
@@ -7,4 +7,6 @@ psql -v ON_ERROR_STOP=1 -A -t -q -d mas \
   -c "select true from ${shard}_tmp.paths limit 1;" \
   || (cd "$here" && ./shard_reset.sh "$shard")
 
-(cd "$here" && concurrent -v -b 10000 -r 3 ./ingest.sh "${shard}_tmp")
+batch_size=${INGEST_BATCH_SIZE:-10000}
+conc_limit=${INGEST_CONC_LIMIT:-$(nproc --all)}
+(cd "$here" && concurrent -v -l $conc_limit -b $batch_size -r 3 ./ingest.sh "${shard}_tmp")


### PR DESCRIPTION
This PR enables configurable concurrent limit and batch size of `shard_ingest`.