### PR TITLE
added support for auto-catalogues

### DIFF
--- a/mas/api/api.go
+++ b/mas/api/api.go
@@ -118,6 +118,27 @@ func handler(response http.ResponseWriter, request *http.Request) {
 			request.FormValue("namespace"),
 		).Scan(&payload)
 
+	} else if _, ok := query["list_root_gpath"]; ok {
+		err = db.QueryRow(
+			`select mas_list_root_gpath() as json`,
+		).Scan(&payload)
+
+	} else if _, ok := query["list_sub_gpath"]; ok {
+		err = db.QueryRow(
+			`select mas_list_sub_gpath(
+				nullif($1,'')::text
+			) as json`,
+			request.URL.Path,
+		).Scan(&payload)
+
+	} else if _, ok := query["generate_layers"]; ok {
+		err = db.QueryRow(
+			`select mas_generate_layers(
+				nullif($1,'')::text
+			) as json`,
+			request.URL.Path,
+		).Scan(&payload)
+
 	} else {
 		httpJSONError(response, errors.New("unknown operation; currently supported: ?intersects, ?timestamps, ?extents"), 400)
 		return

--- a/mas/api/mas.sql
+++ b/mas/api/mas.sql
@@ -738,17 +738,15 @@ create or replace function public.mas_generate_layers (
           t1.ns,
           'name',
           t1.ns,
-          'namespace',
-          gpath,
           'time_generator',
           'mas',
           'data_source',
           gpath,
           'rgb_products',
-          array_fill(t1.ns, ARRAY[1]),
-          'axes',
-          t2.axis
-          ) as layer
+          array_fill(t1.ns, ARRAY[1])
+          ) || case when t2.axis is not null then
+                jsonb_build_object('axes', t2.axis)
+              else '{}'::jsonb end as layer
           from (
             select jsonb_array_elements(namespaces->'namespaces') as ns
           ) t1

--- a/ows.go
+++ b/ows.go
@@ -1694,7 +1694,6 @@ func owsHandler(w http.ResponseWriter, r *http.Request) {
 		configMap.Store("config", confMap)
 		config, _ = conf[namespace]
 	}
-	log.Printf("eeeee %v, %#v", namespace, config)
 	config.ServiceConfig.NameSpace = namespace
 	generalHandler(config, w, r)
 }

--- a/ows.go
+++ b/ows.go
@@ -1696,14 +1696,14 @@ func cataloguesHandler(w http.ResponseWriter, r *http.Request) {
 		r.URL.Path = upath
 	}
 	upath = strings.TrimSpace(path.Clean(upath))
-	
 
 	var cataloguePath string
 	if len(upath) > len("/catalogues/") {
 		cataloguePath = upath[len("/catalogues/"):]
 	}
 
-	catalogueHandler := utils.NewCatalogueHandler(cataloguePath, "catalogues", utils.DataDir+"/static/catalogues", "127.0.0.1:8888", utils.DataDir + "/templates", w)
+	host := fmt.Sprintf("%s://%s", utils.ParseRequestProtocol(r), r.Host)
+	catalogueHandler := utils.NewCatalogueHandler(cataloguePath, host, "catalogues", utils.DataDir+"/static/catalogues", "127.0.0.1:9512", utils.DataDir+"/templates", w)
 	catalogueHandler.Process()
 
 	w.Header().Set("Access-Control-Allow-Origin", "*")

--- a/ows.go
+++ b/ows.go
@@ -1689,10 +1689,34 @@ func fileHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func cataloguesHandler(w http.ResponseWriter, r *http.Request) {
+	upath := r.URL.Path
+	if !strings.HasPrefix(upath, "/") {
+		upath = "/" + upath
+		r.URL.Path = upath
+	}
+	upath = strings.TrimSpace(path.Clean(upath))
+	
+
+	var cataloguePath string
+	if len(upath) > len("/catalogues/") {
+		cataloguePath = upath[len("/catalogues/"):]
+	}
+
+	catalogueHandler := utils.NewCatalogueHandler(cataloguePath, "catalogues", utils.DataDir+"/static/catalogues", "127.0.0.1:8888", utils.DataDir + "/templates", w)
+	catalogueHandler.Process()
+
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
+
+}
+
 func main() {
 	http.HandleFunc("/", fileHandler)
 	http.HandleFunc("/ows", owsHandler)
 	http.HandleFunc("/ows/", owsHandler)
+	http.HandleFunc("/catalogues", cataloguesHandler)
+	http.HandleFunc("/catalogues/", cataloguesHandler)
 
 	listeningHost := fmt.Sprintf("0.0.0.0:%d", *port)
 	Info.Printf("GSKY is listening on %s", listeningHost)

--- a/ows.go
+++ b/ows.go
@@ -1791,12 +1791,15 @@ func cataloguesHandler(w http.ResponseWriter, r *http.Request) {
 	staticRoot := filepath.Join(utils.DataDir, "static", utils.CatalogueDirName)
 	templateRoot := filepath.Join(utils.DataDir, "templates")
 
-	catalogueHandler := utils.NewCatalogueHandler(cataloguePath, host, urlPathRoot, staticRoot, masAddress, templateRoot, w)
+	catalogueHandler := utils.NewCatalogueHandler(cataloguePath, host, urlPathRoot, staticRoot, masAddress, templateRoot, *verbose, w)
 
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")
 
-	catalogueHandler.Process()
+	status := catalogueHandler.Process()
+	if status == 1 {
+		fileHandler(w, r)
+	}
 }
 
 func main() {

--- a/templates/catalogue_index.tpl
+++ b/templates/catalogue_index.tpl
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<header>
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=Edge">
+<title>GSKY Catalogues</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="index, follow">
+<style>
+body {
+  font-family:"Segoe UI","Fira Sans","Droid Sans","Helvetica Neue","Arial","sans-serif";
+  font-size: 16px;
+}
+
+#header {
+  padding-top: 18px;
+  padding-bottom: 18px;
+  margin-top: 0px;
+  padding-left: 0px;
+  padding-right: 0px;
+  margin-bottom: 15px;
+  background-color: #fafbfc;
+  border-bottom: 0.5px solid #eeeeee; 
+}
+
+#header_container {
+  width: 980px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+#header_container h2 {
+  color: #24292e;
+}
+
+#container {
+  width: 980px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+br{
+  display: block;
+  margin: 5.7px 0;
+  content: " ";
+  border: 0.5px solid #000000;
+}
+
+ul {
+  list-style-type:none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav li {
+  display: inline-block;
+  font-weight: bold;
+}
+
+.list li {
+  padding-top: 10px;
+  margin-left: 20px;
+  padding-bottom: 10px;
+  border-bottom: 0.4px solid #eeeeee;
+}
+
+
+.list li:hover {
+    background-color: #eaecef;
+}
+
+a {
+    text-decoration: none;
+    display: block;
+    padding-left: 5px;
+}
+
+a:link, a:visited {
+    color: #0366d6;
+}
+
+a:hover {
+    color: #0366d6;
+    text-decoration: underline;
+}
+</style>
+</header>
+<body>
+<div id="header">
+  <div id="header_container">
+    <h2>GSKY Catalogues</h2>
+  </div>
+</div>
+<div id="container">
+  <ul class="nav">
+  {{ range $index, $nav := .Navigations }}
+  <li><a href="{{ $nav.URL }}">{{ $nav.Title }}</a></li>
+  <li>/</li>
+  {{ end }}
+  <li>{{ .Title }}</li>
+  </ul>
+
+  <br />
+
+  <ul class="list">
+  {{ range $index, $e := .Endpoints }}
+  <li><a href="{{ $e.URL }}">{{ $e.Title }}</a></li>
+  {{ end }}
+  </ul>
+</div>
+
+</body>
+</html>
+

--- a/templates/gsky_layers.tpl
+++ b/templates/gsky_layers.tpl
@@ -1,0 +1,30 @@
+{
+    "layers": [
+        {{ range $index, $layer := .Layers -}}
+        {{ if $index -}},{{- end }}
+        {
+            "title": "{{ $layer.Title }}",
+            "name": "{{ $layer.Name }}",
+            "data_source": "{{ $layer.DataSource }}",
+            "rgb_products": [
+              {{- range $ip, $var := $layer.RGBProducts -}}
+              {{ if $ip -}},{{- end }}
+              "{{ $var }}"
+              {{- end }}
+            ],
+            "time_generator": "mas"
+            {{- if $layer.AxesInfo }},{{ end -}}
+            {{ if $layer.AxesInfo }}
+            "axes": [
+              {{- range $ia, $axis := $layer.AxesInfo -}}
+              {{ if $ia -}},{{- end }}
+              { "name": "{{ $axis.Name }}", "default": "{{ $axis.Default }}",
+                "values": [ {{- range $iv, $val := $axis.Values }}{{ if $iv -}},{{- end }}"{{ $val }}"{{ end }} ]
+              }
+              {{- end }}
+            ]
+            {{- end }}
+        }
+        {{- end }}
+    ]
+}

--- a/templates/terria_catalog.tpl
+++ b/templates/terria_catalog.tpl
@@ -1,0 +1,26 @@
+{
+    "catalog": [
+      {
+         "type": "group",
+         "name": "{{ .Namespace }}",
+         "preserveOrder": true,
+         "isOpen": true,
+         "items": [
+          {{ range $index, $layer := .Layers }}
+          {
+              "name": "{{ $layer.Title }}",
+              "type": "wms",
+              "url": "{{ $layer.DataURL }}",
+              "layers": "{{ $layer.Name }}",
+              "linkedWcsUrl": "{{ $layer.DataURL }}",
+              "linkedWcsCoverage": "{{ $layer.Name }}",
+              "ignoreUnknownTileErrors": true,
+              "supportsColorScaleRange": true,
+              "opacity": 1.0,
+              "colorScaleMinimum": 0.0,
+              "colorScaleMaximum": 1.0,
+          },{{ end }}
+        ]
+      }
+  ]
+}

--- a/templates/terria_catalog.tpl
+++ b/templates/terria_catalog.tpl
@@ -19,6 +19,9 @@
               "opacity": 1.0,
               "colorScaleMinimum": 0.0,
               "colorScaleMaximum": 1.0,
+              "parameters": {
+                "colorscheme": "rainbow",
+              },
           },{{ end }}
         ]
       }

--- a/utils/catalogues.go
+++ b/utils/catalogues.go
@@ -1,60 +1,42 @@
 package utils
 
 import (
-	"strings"
-	"path/filepath"
-	"os"
-	"io"
-	"encoding/json"
-//	"bytes"
-	"log"
-)
-
-/*
-import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"image/color"
-	"io"
 	"io/ioutil"
 	"log"
-	"math"
 	"net/http"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"sort"
 	"strings"
-	"sync"
-	"syscall"
-	"time"
-
-	"github.com/edisonguo/jet"
 )
-*/
+
+const catalogueHomeTitle = "Home"
 
 type CatalogueHandler struct {
-	Path string
-	URLRoot string
-	StaticRoot string
-	MasAddress string
+	Path              string
+	URLHost           string
+	URLPathRoot       string
+	StaticRoot        string
+	MasAddress        string
 	IndexTemplateRoot string
-	Output io.Writer
+	Output            http.ResponseWriter
 }
 
-func NewCatalogueHandler(path string, urlRoot, staticRoot string, masAddress string, indexTemplateRoot string, output io.Writer) *CatalogueHandler {
-	return & CatalogueHandler {
-		Path: path,
-		URLRoot: urlRoot,
-		StaticRoot: staticRoot,
-		MasAddress: masAddress,
+func NewCatalogueHandler(path, urlHost, urlPathRoot, staticRoot, masAddress, indexTemplateRoot string, output http.ResponseWriter) *CatalogueHandler {
+	return &CatalogueHandler{
+		Path:              path,
+		URLHost:           urlHost,
+		URLPathRoot:       urlPathRoot,
+		StaticRoot:        staticRoot,
+		MasAddress:        masAddress,
 		IndexTemplateRoot: indexTemplateRoot,
-		Output: output,
+		Output:            output,
 	}
 }
 
 func (h *CatalogueHandler) Process() {
+	h.Path = "/" + strings.Trim(h.Path, "/")
 	ext := filepath.Ext(h.Path)
 
 	indexFile := h.Path
@@ -73,108 +55,157 @@ func (h *CatalogueHandler) Process() {
 		return
 	}
 
-	log.Printf("1111 %v, %v", absPath, h.StaticRoot)
 	if !strings.HasPrefix(absPath, h.StaticRoot) {
 		return
 	}
 
 	if _, err := os.Stat(absPath); err == nil {
-		log.Printf("found index file: %v", absPath)
+		type Payload struct {
+			Host string
+		}
+		payload := &Payload{Host: h.URLHost}
+		err := ExecuteWriteTemplateFile(h.Output, payload, absPath)
+		if err != nil {
+			http.Error(h.Output, err.Error(), 500)
+			return
+		}
+
 	} else {
 		indexPath := h.Path
 		if len(ext) > 0 {
 			indexPath = filepath.Dir(indexPath)
 		}
-		if len(indexPath) == 0 {
-			log.Printf("root catalogue")
+		if indexPath == "/" || len(indexPath) == 0 {
+			h.renderRootCataloguePage()
 		} else {
-			log.Printf("non root catalogue")
 			h.renderCataloguePage(indexPath)
 		}
 	}
 }
 
-type Anchor struct {
-	URL string
+type gpathMetadata struct {
+	Error         string   `json:"error"`
+	Paths         []string `json:"sub_paths"`
+	HasNamespaces bool     `json:"has_namespaces"`
+	PathRoot      string   `json:"gpath_root"`
+}
+
+type anchor struct {
+	URL   string
 	Title string
 }
 
-type RenderData struct {
-	Navigations []Anchor
-	Endpoints []Anchor
-	Title string
+type renderData struct {
+	Navigations []*anchor
+	Endpoints   []*anchor
+	Title       string
+}
+
+func (h *CatalogueHandler) renderRootCataloguePage() {
+	gpathInfo, err := h.getGPathMetadata("", "list_root_gpath")
+	if err != nil {
+		log.Printf("%v", err)
+		return
+	}
+
+	var rd renderData
+	rd.Title = catalogueHomeTitle
+
+	for _, path := range gpathInfo.Paths {
+		urlPath := filepath.Join(h.URLPathRoot, path)
+		a := &anchor{
+			URL:   fmt.Sprintf("%s/%s", h.URLHost, urlPath),
+			Title: path,
+		}
+		rd.Endpoints = append(rd.Endpoints, a)
+	}
+
+	err = ExecuteWriteTemplateFile(h.Output, rd, filepath.Join(h.IndexTemplateRoot, "catalogue_index.tpl"))
+	if err != nil {
+		log.Printf("%v", err)
+		return
+	}
 }
 
 func (h *CatalogueHandler) renderCataloguePage(indexPath string) {
-	/*
-	url := strings.Replace(fmt.Sprintf("http://%s%s?timestamps", g.MasAddress, indexPath), " ", "%20", -1)
+	gpathInfo, err := h.getGPathMetadata(indexPath, "list_sub_gpath")
+	if err != nil {
+		log.Printf("%v", err)
+		return
+	}
+
+	var rd renderData
+	relIndexPath := indexPath[len(gpathInfo.PathRoot):]
+	parts := strings.Split(relIndexPath, "/")
+	if strings.HasPrefix(relIndexPath, "/") {
+		parts = parts[1:]
+	}
+
+	urlRoot := fmt.Sprintf("%s/%s", h.URLHost, h.URLPathRoot)
+	rd.Navigations = append(rd.Navigations, &anchor{URL: urlRoot, Title: catalogueHomeTitle})
+	if len(parts) > 0 {
+		if len(gpathInfo.PathRoot) < len(indexPath) {
+			urlPath := fmt.Sprintf("%s/%s", h.URLHost, filepath.Join(h.URLPathRoot, gpathInfo.PathRoot))
+			rd.Navigations = append(rd.Navigations, &anchor{URL: urlPath, Title: gpathInfo.PathRoot})
+			rd.Title = parts[len(parts)-1]
+		} else {
+			rd.Title = gpathInfo.PathRoot
+		}
+	}
+
+	for ip, p := range parts[:len(parts)-1] {
+		relPath := filepath.Join(gpathInfo.PathRoot, strings.Join(parts[:ip+1], "/"))
+		relPath = strings.Trim(relPath, "/")
+		a := &anchor{
+			URL:   fmt.Sprintf("%s/%s", urlRoot, relPath),
+			Title: p,
+		}
+		rd.Navigations = append(rd.Navigations, a)
+	}
+
+	if gpathInfo.HasNamespaces {
+		urlPath := filepath.Join("ows", indexPath)
+		a := &anchor{
+			URL:   fmt.Sprintf("%s/%s?service=WMS&request=GetCapabilities&version=1.3.0", h.URLHost, urlPath),
+			Title: "WMS GetCapabilities",
+		}
+		rd.Endpoints = append(rd.Endpoints, a)
+	}
+
+	for _, path := range gpathInfo.Paths {
+		subPath := filepath.Base(path)
+		urlPath := filepath.Join(h.URLPathRoot, indexPath, subPath)
+		a := &anchor{
+			URL:   fmt.Sprintf("%s/%s", h.URLHost, urlPath),
+			Title: subPath,
+		}
+		rd.Endpoints = append(rd.Endpoints, a)
+	}
+
+	err = ExecuteWriteTemplateFile(h.Output, rd, filepath.Join(h.IndexTemplateRoot, "catalogue_index.tpl"))
+	if err != nil {
+		log.Printf("%v", err)
+		return
+	}
+}
+
+func (h *CatalogueHandler) getGPathMetadata(indexPath string, queryOp string) (*gpathMetadata, error) {
+	url := strings.Replace(fmt.Sprintf("http://%s%s?%s", h.MasAddress, indexPath, queryOp), " ", "%20", -1)
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Printf("MAS http error: %v,%v", url, err)
-		return emptyDates, token
+		return nil, fmt.Errorf("MAS (%s) error: %v,%v", queryOp, url, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Printf("MAS http error: %v,%v", url, err)
-		return emptyDates, token
-	}
-	*/
-
-	body := []byte(`{"sub_paths": ["/g/data/xu18/ga/ga_ls7e_ard_3/088/080/1999", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2000", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2001", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2002", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2003", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2004", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2005", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2006", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2007", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2008", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2009", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2010", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2011", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2012", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2013", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2014", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2015"], "has_namespaces": false}`)
-
-	type GPathInfo struct {
-		Error      string   `json:"error"`
-		Paths []string `json:"sub_paths"`
-		HasNamespaces bool `json:"has_namespaces"`
+		return nil, fmt.Errorf("MAS (%s) error: %v,%v", queryOp, url, err)
 	}
 
-	var gpathInfo GPathInfo
-	err := json.Unmarshal(body, &gpathInfo)
+	var gpathInfo gpathMetadata
+	err = json.Unmarshal(body, &gpathInfo)
 	if err != nil {
-		log.Printf("MAS json response error: %v", err)
-		return
+		return nil, fmt.Errorf("MAS (%s) json response error: %v", queryOp, err)
 	}
-
-	var renderData RenderData	
-
-	parts := strings.Split(indexPath, "/")
-	if len(parts) > 0 {
-		renderData.Title = parts[len(parts)-1]
-	}
-
-	var homeRelParts []string
-	for ii := 0; ii < len(parts); ii++ {
-		homeRelParts = append(homeRelParts, "..")
-	}
-	relHomePath := strings.Join(homeRelParts, "/")
-	renderData.Navigations = append(renderData.Navigations, Anchor {URL: relHomePath, Title: "Home"})
-	for ip, p := range parts[:len(parts)-1] {
-		var relParts []string
-		for ii := len(parts)-1; ii >= ip; ii-- {
-			relParts = append(relParts, "..")
-		} 
-		relPath := strings.Join(relParts, "/")
-		a := Anchor {
-			URL: filepath.Join(h.URLRoot, relPath),
-			Title: p,
-		}
-		renderData.Navigations = append(renderData.Navigations, a)
-	}
-
-	for _, path := range gpathInfo.Paths {
-		subPath := filepath.Base(path)
-		a := Anchor {
-			URL: "get caps url",
-			Title: subPath,
-		}
-		renderData.Endpoints = append(renderData.Endpoints, a)
-	}
-
-	err = ExecuteWriteTemplateFile(h.Output, renderData, filepath.Join(h.IndexTemplateRoot, "catalogue_index.tpl"))
-	if err != nil {
-		log.Printf("%v", err)
-		return
-	}
+	return &gpathInfo, nil
 }

--- a/utils/catalogues.go
+++ b/utils/catalogues.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 )
 
+const CatalogueDirName = "catalogues"
 const catalogueHomeTitle = "Home"
 
 type CatalogueHandler struct {
@@ -207,5 +208,9 @@ func (h *CatalogueHandler) getGPathMetadata(indexPath string, queryOp string) (*
 	if err != nil {
 		return nil, fmt.Errorf("MAS (%s) json response error: %v", queryOp, err)
 	}
+	if len(gpathInfo.Error) > 0 {
+		return nil, fmt.Errorf("MAS (%s) json response error: %v", queryOp, gpathInfo.Error)
+	}
+
 	return &gpathInfo, nil
 }

--- a/utils/catalogues.go
+++ b/utils/catalogues.go
@@ -1,0 +1,180 @@
+package utils
+
+import (
+	"strings"
+	"path/filepath"
+	"os"
+	"io"
+	"encoding/json"
+//	"bytes"
+	"log"
+)
+
+/*
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"image/color"
+	"io"
+	"io/ioutil"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/edisonguo/jet"
+)
+*/
+
+type CatalogueHandler struct {
+	Path string
+	URLRoot string
+	StaticRoot string
+	MasAddress string
+	IndexTemplateRoot string
+	Output io.Writer
+}
+
+func NewCatalogueHandler(path string, urlRoot, staticRoot string, masAddress string, indexTemplateRoot string, output io.Writer) *CatalogueHandler {
+	return & CatalogueHandler {
+		Path: path,
+		URLRoot: urlRoot,
+		StaticRoot: staticRoot,
+		MasAddress: masAddress,
+		IndexTemplateRoot: indexTemplateRoot,
+		Output: output,
+	}
+}
+
+func (h *CatalogueHandler) Process() {
+	ext := filepath.Ext(h.Path)
+
+	indexFile := h.Path
+	if len(ext) > 0 {
+		if !strings.HasSuffix(h.Path, "index.html") {
+			return
+		} else {
+			indexFile = filepath.Join(h.StaticRoot, indexFile)
+		}
+	} else {
+		indexFile = filepath.Join(h.StaticRoot, indexFile, "index.html")
+	}
+
+	absPath, err := filepath.Abs(indexFile)
+	if err != nil {
+		return
+	}
+
+	log.Printf("1111 %v, %v", absPath, h.StaticRoot)
+	if !strings.HasPrefix(absPath, h.StaticRoot) {
+		return
+	}
+
+	if _, err := os.Stat(absPath); err == nil {
+		log.Printf("found index file: %v", absPath)
+	} else {
+		indexPath := h.Path
+		if len(ext) > 0 {
+			indexPath = filepath.Dir(indexPath)
+		}
+		if len(indexPath) == 0 {
+			log.Printf("root catalogue")
+		} else {
+			log.Printf("non root catalogue")
+			h.renderCataloguePage(indexPath)
+		}
+	}
+}
+
+type Anchor struct {
+	URL string
+	Title string
+}
+
+type RenderData struct {
+	Navigations []Anchor
+	Endpoints []Anchor
+	Title string
+}
+
+func (h *CatalogueHandler) renderCataloguePage(indexPath string) {
+	/*
+	url := strings.Replace(fmt.Sprintf("http://%s%s?timestamps", g.MasAddress, indexPath), " ", "%20", -1)
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Printf("MAS http error: %v,%v", url, err)
+		return emptyDates, token
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("MAS http error: %v,%v", url, err)
+		return emptyDates, token
+	}
+	*/
+
+	body := []byte(`{"sub_paths": ["/g/data/xu18/ga/ga_ls7e_ard_3/088/080/1999", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2000", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2001", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2002", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2003", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2004", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2005", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2006", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2007", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2008", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2009", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2010", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2011", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2012", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2013", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2014", "/g/data/xu18/ga/ga_ls7e_ard_3/088/080/2015"], "has_namespaces": false}`)
+
+	type GPathInfo struct {
+		Error      string   `json:"error"`
+		Paths []string `json:"sub_paths"`
+		HasNamespaces bool `json:"has_namespaces"`
+	}
+
+	var gpathInfo GPathInfo
+	err := json.Unmarshal(body, &gpathInfo)
+	if err != nil {
+		log.Printf("MAS json response error: %v", err)
+		return
+	}
+
+	var renderData RenderData	
+
+	parts := strings.Split(indexPath, "/")
+	if len(parts) > 0 {
+		renderData.Title = parts[len(parts)-1]
+	}
+
+	var homeRelParts []string
+	for ii := 0; ii < len(parts); ii++ {
+		homeRelParts = append(homeRelParts, "..")
+	}
+	relHomePath := strings.Join(homeRelParts, "/")
+	renderData.Navigations = append(renderData.Navigations, Anchor {URL: relHomePath, Title: "Home"})
+	for ip, p := range parts[:len(parts)-1] {
+		var relParts []string
+		for ii := len(parts)-1; ii >= ip; ii-- {
+			relParts = append(relParts, "..")
+		} 
+		relPath := strings.Join(relParts, "/")
+		a := Anchor {
+			URL: filepath.Join(h.URLRoot, relPath),
+			Title: p,
+		}
+		renderData.Navigations = append(renderData.Navigations, a)
+	}
+
+	for _, path := range gpathInfo.Paths {
+		subPath := filepath.Base(path)
+		a := Anchor {
+			URL: "get caps url",
+			Title: subPath,
+		}
+		renderData.Endpoints = append(renderData.Endpoints, a)
+	}
+
+	err = ExecuteWriteTemplateFile(h.Output, renderData, filepath.Join(h.IndexTemplateRoot, "catalogue_index.tpl"))
+	if err != nil {
+		log.Printf("%v", err)
+		return
+	}
+}

--- a/utils/config.go
+++ b/utils/config.go
@@ -588,6 +588,70 @@ func LoadConfigOnDemand(searchPath string, namespace string, verbose bool) (map[
 	return nil, fmt.Errorf("namespace not found: %s", namespace)
 }
 
+func LoadConfigFromMAS(masAddress, namespace string, rootConfig *Config, verbose bool) (map[string]*Config, error) {
+	queryOp := "generate_layers"
+	url := strings.Replace(fmt.Sprintf("http://%s/%s?%s", masAddress, namespace, queryOp), " ", "%20", -1)
+	if verbose {
+		log.Printf("%s: %s", queryOp, url)
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("MAS (%s) error: %v,%v", queryOp, url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("MAS (%s) error: %v,%v", queryOp, url, err)
+	}
+
+	type MasLayers struct {
+		Error  string  `json:"error"`
+		Layers []Layer `json:"layers"`
+	}
+	var masLayers MasLayers
+	err = json.Unmarshal(body, &masLayers)
+	if err != nil {
+		return nil, fmt.Errorf("MAS (%s) json response error: %v", queryOp, err)
+	}
+
+	if len(masLayers.Error) > 0 {
+		return nil, fmt.Errorf("MAS (%s) json response error: %v", queryOp, masLayers.Error)
+	}
+
+	config := &Config{
+		ServiceConfig: ServiceConfig{
+			MASAddress:  rootConfig.ServiceConfig.MASAddress,
+			WorkerNodes: rootConfig.ServiceConfig.WorkerNodes,
+		},
+	}
+
+	config.Layers = make([]Layer, len(masLayers.Layers))
+	for il, layer := range masLayers.Layers {
+		layer.TimestampsLoadStrategy = "on_demand"
+		config.Layers[il] = layer
+	}
+
+	configStr, cfgErr := json.Marshal(config)
+	if cfgErr != nil {
+		return nil, fmt.Errorf("MAS config error: %v", cfgErr)
+	}
+
+	err = config.LoadConfigString(configStr, verbose)
+	if err != nil {
+		return nil, fmt.Errorf("MAS config error: %v", err)
+	}
+
+	err = config.postprocessConfig(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("MAS config error: %v", err)
+	}
+
+	configMap := make(map[string]*Config)
+	configMap[namespace] = config
+	return configMap, nil
+}
+
 func LoadAllConfigFiles(searchPath string, verbose bool) (map[string]*Config, error) {
 	var err error
 	configMap := make(map[string]*Config)
@@ -636,92 +700,9 @@ func LoadAllConfigFiles(searchPath string, verbose bool) (map[string]*Config, er
 				}
 
 				configMap[relPath] = config
-
-				for i := range config.Layers {
-					ns := relPath
-					if relPath == "." {
-						ns = ""
-					}
-
-					if len(config.Layers[i].MASAddress) == 0 {
-						config.Layers[i].MASAddress = config.ServiceConfig.MASAddress
-					}
-
-					if len(config.Layers[i].Overviews) > 0 {
-						for ii, ovr := range config.Layers[i].Overviews {
-							if len(ovr.DataSource) == 0 {
-								return fmt.Errorf("%s, %s: overview[%d] has no data_source", config.Layers[i].Name, ns, ii)
-							}
-
-							if ovr.ZoomLimit <= 0 {
-								return fmt.Errorf("%s, %s: overview[%d] has no zoom_limit", config.Layers[i].Name, ns, ii)
-							}
-
-							if len(config.Layers[i].Overviews[ii].MASAddress) == 0 {
-								config.Layers[i].Overviews[ii].MASAddress = config.Layers[i].MASAddress
-							}
-						}
-						sort.Slice(config.Layers[i].Overviews, func(m, n int) bool { return config.Layers[m].ZoomLimit < config.Layers[n].ZoomLimit })
-					}
-					config.Layers[i].NameSpace = ns
-					for j := range config.Layers[i].Styles {
-						config.Layers[i].Styles[j].OWSHostname = config.Layers[i].OWSHostname
-						config.Layers[i].Styles[j].NameSpace = config.Layers[i].NameSpace
-						if len(config.Layers[i].Styles[j].DataSource) == 0 {
-							config.Layers[i].Styles[j].DataSource = config.Layers[i].DataSource
-						}
-						if len(config.Layers[i].Styles[j].MASAddress) == 0 {
-							config.Layers[i].Styles[j].MASAddress = config.Layers[i].MASAddress
-						}
-						if config.Layers[i].Styles[j].LegendWidth <= 0 {
-							config.Layers[i].Styles[j].LegendWidth = DefaultLegendWidth
-						}
-						if config.Layers[i].Styles[j].LegendHeight <= 0 {
-							config.Layers[i].Styles[j].LegendHeight = DefaultLegendHeight
-						}
-
-						bandExpr, err := ParseBandExpressions(config.Layers[i].Styles[j].RGBProducts)
-						if err != nil {
-							return fmt.Errorf("Layer %v, style %v, RGBExpression parsing error: %v", config.Layers[i].Name, config.Layers[i].Styles[j].Name, err)
-						}
-						config.Layers[i].Styles[j].RGBExpressions = bandExpr
-
-						if len(config.Layers[i].Styles[j].FeatureInfoBands) > 0 {
-							featureInfoExpr, err := ParseBandExpressions(config.Layers[i].Styles[j].FeatureInfoBands)
-							if err != nil {
-								return fmt.Errorf("Layer %v, style %v, FeatureInfoExpression parsing error: %v", config.Layers[i].Name, config.Layers[i].Styles[j].Name, err)
-							}
-							config.Layers[i].Styles[j].FeatureInfoExpressions = featureInfoExpr
-						}
-
-						if len(config.Layers[i].Styles[j].InputLayers) == 0 && len(config.Layers[i].InputLayers) > 0 {
-							config.Layers[i].Styles[j].InputLayers = config.Layers[i].InputLayers
-						}
-
-						if len(config.Layers[i].Styles[j].InputLayers) > 0 {
-							for k := range config.Layers[i].Styles[j].InputLayers {
-								if len(config.Layers[i].Styles[j].InputLayers[k].Name) == 0 {
-									config.Layers[i].Styles[j].InputLayers[k].Name = config.Layers[i].Name
-								}
-							}
-						}
-
-						if len(config.Layers[i].Styles[j].DisableServices) == 0 && len(config.Layers[i].DisableServices) > 0 {
-							config.Layers[i].Styles[j].DisableServices = config.Layers[i].DisableServices
-						}
-
-						if len(config.Layers[i].Styles[j].Overviews) == 0 && len(config.Layers[i].Overviews) > 0 {
-							config.Layers[i].Styles[j].Overviews = config.Layers[i].Overviews
-						}
-
-						if config.Layers[i].Styles[j].ZoomLimit == 0.0 && config.Layers[i].ZoomLimit != 0.0 {
-							config.Layers[i].Styles[j].ZoomLimit = config.Layers[i].ZoomLimit
-						}
-
-						if !strings.HasPrefix(config.Layers[i].Styles[j].Name, "__") {
-							config.Layers[i].Styles[j].Visibility = "visible"
-						}
-					}
+				e = config.postprocessConfig(relPath)
+				if e != nil {
+					return e
 				}
 			}
 			return nil
@@ -785,6 +766,96 @@ func Unmarshal(data []byte, i interface{}) error {
 		err = fmt.Errorf("Error in line %d, char %d: %s\n%s",
 			line, pos, syntaxErr, data[start:end])
 		return err
+	}
+
+	return nil
+}
+
+func (config *Config) postprocessConfig(ns string) error {
+	for i := range config.Layers {
+		if ns == "." {
+			ns = ""
+		}
+
+		if len(config.Layers[i].MASAddress) == 0 {
+			config.Layers[i].MASAddress = config.ServiceConfig.MASAddress
+		}
+
+		if len(config.Layers[i].Overviews) > 0 {
+			for ii, ovr := range config.Layers[i].Overviews {
+				if len(ovr.DataSource) == 0 {
+					return fmt.Errorf("%s, %s: overview[%d] has no data_source", config.Layers[i].Name, ns, ii)
+				}
+
+				if ovr.ZoomLimit <= 0 {
+					return fmt.Errorf("%s, %s: overview[%d] has no zoom_limit", config.Layers[i].Name, ns, ii)
+				}
+
+				if len(config.Layers[i].Overviews[ii].MASAddress) == 0 {
+					config.Layers[i].Overviews[ii].MASAddress = config.Layers[i].MASAddress
+				}
+			}
+			sort.Slice(config.Layers[i].Overviews, func(m, n int) bool { return config.Layers[m].ZoomLimit < config.Layers[n].ZoomLimit })
+		}
+		config.Layers[i].NameSpace = ns
+		for j := range config.Layers[i].Styles {
+			config.Layers[i].Styles[j].OWSHostname = config.Layers[i].OWSHostname
+			config.Layers[i].Styles[j].NameSpace = config.Layers[i].NameSpace
+			if len(config.Layers[i].Styles[j].DataSource) == 0 {
+				config.Layers[i].Styles[j].DataSource = config.Layers[i].DataSource
+			}
+			if len(config.Layers[i].Styles[j].MASAddress) == 0 {
+				config.Layers[i].Styles[j].MASAddress = config.Layers[i].MASAddress
+			}
+			if config.Layers[i].Styles[j].LegendWidth <= 0 {
+				config.Layers[i].Styles[j].LegendWidth = DefaultLegendWidth
+			}
+			if config.Layers[i].Styles[j].LegendHeight <= 0 {
+				config.Layers[i].Styles[j].LegendHeight = DefaultLegendHeight
+			}
+
+			bandExpr, err := ParseBandExpressions(config.Layers[i].Styles[j].RGBProducts)
+			if err != nil {
+				return fmt.Errorf("Layer %v, style %v, RGBExpression parsing error: %v", config.Layers[i].Name, config.Layers[i].Styles[j].Name, err)
+			}
+			config.Layers[i].Styles[j].RGBExpressions = bandExpr
+
+			if len(config.Layers[i].Styles[j].FeatureInfoBands) > 0 {
+				featureInfoExpr, err := ParseBandExpressions(config.Layers[i].Styles[j].FeatureInfoBands)
+				if err != nil {
+					return fmt.Errorf("Layer %v, style %v, FeatureInfoExpression parsing error: %v", config.Layers[i].Name, config.Layers[i].Styles[j].Name, err)
+				}
+				config.Layers[i].Styles[j].FeatureInfoExpressions = featureInfoExpr
+			}
+
+			if len(config.Layers[i].Styles[j].InputLayers) == 0 && len(config.Layers[i].InputLayers) > 0 {
+				config.Layers[i].Styles[j].InputLayers = config.Layers[i].InputLayers
+			}
+
+			if len(config.Layers[i].Styles[j].InputLayers) > 0 {
+				for k := range config.Layers[i].Styles[j].InputLayers {
+					if len(config.Layers[i].Styles[j].InputLayers[k].Name) == 0 {
+						config.Layers[i].Styles[j].InputLayers[k].Name = config.Layers[i].Name
+					}
+				}
+			}
+
+			if len(config.Layers[i].Styles[j].DisableServices) == 0 && len(config.Layers[i].DisableServices) > 0 {
+				config.Layers[i].Styles[j].DisableServices = config.Layers[i].DisableServices
+			}
+
+			if len(config.Layers[i].Styles[j].Overviews) == 0 && len(config.Layers[i].Overviews) > 0 {
+				config.Layers[i].Styles[j].Overviews = config.Layers[i].Overviews
+			}
+
+			if config.Layers[i].Styles[j].ZoomLimit == 0.0 && config.Layers[i].ZoomLimit != 0.0 {
+				config.Layers[i].Styles[j].ZoomLimit = config.Layers[i].ZoomLimit
+			}
+
+			if !strings.HasPrefix(config.Layers[i].Styles[j].Name, "__") {
+				config.Layers[i].Styles[j].Visibility = "visible"
+			}
+		}
 	}
 
 	return nil
@@ -1457,7 +1528,6 @@ func addBandMathVariableConstraints(config *Config, layer *Layer, criteria *Band
 // LoadConfigFile marshalls the config.json document returning an
 // instance of a Config variable containing all the values
 func (config *Config) LoadConfigFile(configFile string, verbose bool) error {
-	*config = Config{}
 	cfg, err := LoadConfigFileTemplate(configFile)
 	if verbose {
 		log.Printf("%v: %v", configFile, string(cfg))
@@ -1467,7 +1537,11 @@ func (config *Config) LoadConfigFile(configFile string, verbose bool) error {
 		return fmt.Errorf("Error while reading config file: %s. Error: %v", configFile, err)
 	}
 
-	err = Unmarshal(cfg, config)
+	return config.LoadConfigString(cfg, verbose)
+}
+
+func (config *Config) LoadConfigString(cfg []byte, verbose bool) error {
+	err := Unmarshal(cfg, config)
 	if err != nil {
 		return fmt.Errorf("Error at JSON parsing config document: %v", err)
 	}
@@ -1484,7 +1558,7 @@ func (config *Config) LoadConfigFile(configFile string, verbose bool) error {
 
 	if config.ServiceConfig.MaxGrpcBufferSize > 0 && config.ServiceConfig.MaxGrpcBufferSize < 10 {
 		config.ServiceConfig.MaxGrpcBufferSize = 0
-		log.Printf("%v: MaxGrpcBufferSize is set to less than 10MB, reset to unlimited", configFile)
+		log.Printf("MaxGrpcBufferSize is set to less than 10MB, reset to unlimited")
 	}
 
 	config.ServiceConfig.MaxGrpcBufferSize = config.ServiceConfig.MaxGrpcBufferSize * 1024 * 1024
@@ -1668,6 +1742,36 @@ func DumpConfig(configs map[string]*Config) (string, error) {
 	}
 
 	return string(configJson), nil
+}
+
+func GetRootConfig(searchPath string, verbose bool) (*Config, error) {
+	var config *Config
+
+	searchPathList := strings.Split(searchPath, ":")
+	for _, rootDir := range searchPathList {
+		rootDir = strings.TrimSpace(rootDir)
+		if len(rootDir) == 0 {
+			continue
+		}
+		configFile := filepath.Join(rootDir, "config.json")
+		if _, e := os.Stat(configFile); e != nil {
+			continue
+		}
+
+		config = &Config{}
+		err := config.LoadConfigFile(configFile, verbose)
+		if err != nil {
+			config = nil
+			log.Printf("Loading root config error: %v", err)
+			continue
+		}
+		break
+	}
+
+	if config == nil {
+		return nil, fmt.Errorf("Root configs not found: %v", searchPath)
+	}
+	return config, nil
 }
 
 func WatchConfig(infoLog, errLog *log.Logger, configMap *sync.Map, verbose bool) {

--- a/utils/config.go
+++ b/utils/config.go
@@ -78,6 +78,7 @@ type ServiceConfig struct {
 	OWSClusterNodes   []string `json:"ows_cluster_nodes"`
 	TempDir           string   `json:"temp_dir"`
 	MaxGrpcBufferSize int      `json:"max_grpc_buffer_size"`
+	EnableAutoLayers  bool     `json:"enable_auto_layers"`
 }
 
 type Mask struct {


### PR DESCRIPTION
This PR adds support for auto-catalogues. Auto-catalogues derives catalogue information from MAS given the `gpath` structure for each shard. With the derived catalogue information, it then constructs layer configs on-the-fly. This feature enables fast prototyping of new datasets. By default, this feature is turned off. To enable this feature, the following steps are required:

* Add `enable_auto_layers: true` to the root config file. The root config file is the config file under the config root directory specified by `-conf_dir`

```
{
  "service_config": {
    "enable_auto_layers": true,
    ....
  },
  ....
}
```

* If `static/catalogues` directory exists, the `index.html` files override the the on-the-fly auto-catalogues. These files need to be removed.  
