### PR TITLE
disabled on-demand timestamps loading by default

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -1616,10 +1616,6 @@ func (config *Config) LoadConfigString(cfg []byte, verbose bool) error {
 		}
 		config.Layers[i].FeatureInfoExpressions = featureInfoExpr
 
-		if len(strings.TrimSpace(config.Layers[i].TimestampsLoadStrategy)) == 0 {
-			config.Layers[i].TimestampsLoadStrategy = "on_demand"
-		}
-
 		if config.Layers[i].TimestampsLoadStrategy != "on_demand" {
 			config.GetLayerDates(i, verbose)
 		}


### PR DESCRIPTION
This PR disables on-demand timestamps loading by default. On-demand timestamps loading is not compatible with blended layers.