### PR TITLE
raised error for empty configs generated from MAS

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -1688,6 +1688,12 @@ func owsHandler(w http.ResponseWriter, r *http.Request) {
 				namespaceErr(err)
 				return
 			}
+			for _, v := range conf {
+				if len(v.Layers) == 0 {
+					namespaceErr(fmt.Errorf("config returned from MAS has no layers"))
+					return
+				}
+			}
 		}
 		for k, v := range conf {
 			confMap[k] = v


### PR DESCRIPTION
This PR raises error for empty configs generated from MAS.