### PR TITLE
fixed on-demand timestamps for a single namespace

### DIFF
--- a/ows.go
+++ b/ows.go
@@ -208,7 +208,10 @@ func serveWMS(ctx context.Context, params utils.WMSParams, conf *utils.Config, r
 
 		if cacheMiss {
 			newConf = conf.Copy(r)
-			utils.LoadConfigTimestamps(newConf, *verbose)
+			err = utils.LoadConfigTimestamps(newConf, *verbose)
+			if err != nil {
+				log.Printf("WMS GetCapabilities LoadConfigTimestamps error: %v", err)
+			}
 		}
 
 		err = utils.ExecuteWriteTemplateFile(w, newConf,

--- a/utils/config.go
+++ b/utils/config.go
@@ -783,8 +783,12 @@ func LoadConfigTimestamps(config *Config, verbose bool) error {
 		config.GetLayerDates(iLayer, verbose)
 	}
 
+	ns := config.ServiceConfig.NameSpace
+	if len(ns) == 0 {
+		ns = "."
+	}
 	confMap := make(map[string]*Config)
-	confMap[config.ServiceConfig.NameSpace] = config
+	confMap[ns] = config
 	for iLayer := range config.Layers {
 		err := config.processFusionTimestamps(iLayer, confMap)
 		if err != nil {


### PR DESCRIPTION
This PR fixes on-demand timestamps for a single namespace.