### PR TITLE
reduced memory footprint for the warper

### DIFF
--- a/worker/gdalprocess/warper.cxx
+++ b/worker/gdalprocess/warper.cxx
@@ -333,7 +333,7 @@ int warp_operation_fast(const char *srcFilePath, char *srcProjRef, double *srcGe
 
 	int nBlocksRead = 0;
 
-	for(auto& it : blockPixelMap) {
+	for(const auto& it : blockPixelMap) {
 		const int nPixels = it.second.first.size();
 		if(nPixels == 0) {
 			continue;

--- a/worker/gdalprocess/warper.cxx
+++ b/worker/gdalprocess/warper.cxx
@@ -19,6 +19,8 @@ reduction of overheads in grpc (de-)serialisation and network traffic.
 #include "warper.hxx"
 #include "coordinate_transform_cache.hxx"
 #include <utility>
+#include <map>
+#include <vector>
 
 #include <iostream>
 
@@ -246,11 +248,7 @@ int warp_operation_fast(const char *srcFilePath, char *srcProjRef, double *srcGe
 
         int srcXBlockSize, srcYBlockSize;
         GDALGetBlockSize(hBand, &srcXBlockSize, &srcYBlockSize);
-
         int nXBlocks = (srcXSize + srcXBlockSize - 1) / srcXBlockSize;
-        int nYBlocks = (srcYSize + srcYBlockSize - 1) / srcYBlockSize;
-
-        void **blockList = nullptr;
 
         *dType = GDALGetRasterDataType(hBand);
 	const GDALDataType srcDataType = *dType;
@@ -264,7 +262,8 @@ int warp_operation_fast(const char *srcFilePath, char *srcProjRef, double *srcGe
         const int dataSize = GDALGetDataTypeSizeBytes(*dType);
 
 	*dstBufSize = dstXSize * dstYSize * dataSize;
-	*dstBuf = malloc(*dstBufSize);
+	uint8_t* pDstBuf = (uint8_t *)malloc(*dstBufSize);
+	*dstBuf = pDstBuf;
 
 	*noData = GDALGetRasterNoDataValue(hBand, nullptr);
 	GDALCopyWords(noData, GDT_Float64, 0, *dstBuf, *dType, dataSize, dstXSize * dstYSize);
@@ -274,98 +273,89 @@ int warp_operation_fast(const char *srcFilePath, char *srcProjRef, double *srcGe
         double *dz = (double *)malloc(dstXSize * sizeof(double));
         int *bSuccess = (int *)malloc(dstXSize * sizeof(int));
 
-        int iDstX, iDstY, _iDstX;
-        for(iDstX = 0; iDstX < dstXSize; iDstX++) {
+        for(int iDstX = 0; iDstX < dstXSize; iDstX++) {
                 dx[dstXSize+iDstX] = iDstX + 0.5 + dstXOff;
         }
 
-	int bCache = -1;
-	int nBlocksRead = 0;
-	for(iDstY = 0; iDstY < dstYSize; iDstY++) {
+	const int dstPixelXSize = dstXSize / srcXBlockSize + 1;
+	const int dstPixelYSize = dstYSize / srcYBlockSize + 1;
+	const int dstPixelSize = dstPixelXSize * dstPixelYSize;
+
+	auto blockPixelMap = std::map<int, std::pair<std::vector<int>, std::vector<int> > >();
+
+	for(int iDstY = 0; iDstY < dstYSize; iDstY++) {
                 memcpy(dx, dx + dstXSize, dstXSize * sizeof(double));
                 const double dfY = iDstY + 0.5 + dstYOff;
-                for(iDstX = 0; iDstX < dstXSize; iDstX++) {
+                for(int iDstX = 0; iDstX < dstXSize; iDstX++) {
                         dy[iDstX] = dfY;
                 }
                 memset(dz, 0, dstXSize * sizeof(double));
 
                 GDALApproxTransform(hApproxTransformArg, TRUE, dstXSize, dx, dy, dz, bSuccess);
 
-                for(iDstX = 0; iDstX < dstXSize; iDstX++) {
+                for(int iDstX = 0; iDstX < dstXSize; iDstX++) {
                         if(!bSuccess[iDstX]) continue;
                         if(dx[iDstX] < 0 || dy[iDstX] < 0) continue;
                         const int iSrcX = (int)(dx[iDstX] + 1.0e-10);
                         const int iSrcY = (int)(dy[iDstX] + 1.0e-10);
                         if(iSrcX >= srcXSize || iSrcY >= srcYSize) continue;
 
-			// If the distance between two consecutive iSrcX are less than srcXBlockSize, we cache the blocks.
-			// Otherwise we only allocate a single buffer of block size and keep overwriting this buffer.
-			// This caching strategy is merely heuristic but appears working across various datasets.
-			if(bCache == -1) {
-				int iSrcXPrev = -1;
-				int iSrcXCurr = -1;
-				int srcStride = -1;
-				for(_iDstX = iDstX; _iDstX < dstXSize; _iDstX++) {
-					if(!bSuccess[_iDstX]) continue;
-					if(dx[_iDstX] < 0) continue;
-					const int _iSrcX = (int)(dx[_iDstX] + 1.0e-10);
-					if(_iSrcX >= srcXSize) continue;
+			const int iDst = iDstY * dstXSize + iDstX;
+			const int iSrc = iSrcY * srcXSize + iSrcX;
 
-					if(iSrcXPrev < 0) {
-						iSrcXPrev = _iSrcX;
-					} else {
-						iSrcXCurr = _iSrcX;
-						break;
-					}
-				}
+                        const int iXBlock = iSrcX / srcXBlockSize;
+                        const int iYBlock = iSrcY / srcYBlockSize;
+			const int iBlock = iXBlock + iYBlock * nXBlocks;
 
-				if(iSrcXPrev >= 0 && iSrcXCurr < iSrcXPrev) {
-					iSrcXCurr = iSrcXPrev;
-				}
-				srcStride = iSrcXCurr - iSrcXPrev;
+			auto it = blockPixelMap.find(iBlock);
+			if(it == blockPixelMap.end()) {
+				auto srcPixels = std::vector<int>();
+				srcPixels.reserve(dstPixelSize);
 
-				bCache = srcStride >= 0 && srcStride < srcXBlockSize;
+				auto dstPixels = std::vector<int>();
+				dstPixels.reserve(dstPixelSize);
 
-				if(!bCache) {
-					blockList = (void **)malloc(sizeof(void *));
-					blockList[0] = malloc(srcXBlockSize * srcYBlockSize * srcDataSize);
-				} else {
-					blockList = (void **)malloc(nXBlocks * nYBlocks * sizeof(void *));
-					memset(blockList, 0, nXBlocks * nYBlocks * sizeof(void *));
-				}
+				blockPixelMap[iBlock] = std::make_pair(std::ref(srcPixels), std::ref(dstPixels));
 			}
+			blockPixelMap[iBlock].first.emplace_back(iSrc);
+			blockPixelMap[iBlock].second.emplace_back(iDst);
+		}
+	}
 
-                        int iXBlock = iSrcX / srcXBlockSize;
-                        int iYBlock = iSrcY / srcYBlockSize;
-                        int iBlock = 0;
+	int nBlocksRead = 0;
 
-			if(!bCache) {
-				err = GDALReadBlock(hBand, iXBlock, iYBlock, blockList[0]);
-				if(err != CE_None) continue;
-				nBlocksRead++;
+	auto blockBuffer = (uint8_t *)malloc(srcXBlockSize * srcYBlockSize * srcDataSize);
+	for(const auto& it : blockPixelMap) {
+		const int iBlock = it.first;
+		const int iXBlock = iBlock % nXBlocks; 
+		const int iYBlock = iBlock / nXBlocks;
 
-			} else {
-				iBlock = iXBlock + iYBlock * nXBlocks;
-	                        if(!blockList[iBlock]) {
-					blockList[iBlock] = malloc(srcXBlockSize * srcYBlockSize * srcDataSize);
-					err = GDALReadBlock(hBand, iXBlock, iYBlock, blockList[iBlock]);
-					if(err != CE_None) continue;
-					nBlocksRead++;
-				}
-			}
+		err = GDALReadBlock(hBand, iXBlock, iYBlock, blockBuffer);
+		if(err != CE_None) continue;
+		nBlocksRead++;
 
-                        int iXBlockOff = iSrcX % srcXBlockSize;
+		for(int i = 0; i < it.second.first.size(); i++) {
+			const int iSrc = it.second.first[i];
+			const int iSrcX = iSrc % srcXSize;
+			const int iSrcY = iSrc / srcXSize;
+
+			const int iDst = it.second.second[i];
+			const int iDstX = iDst % dstXSize;
+			const int iDstY = iDst / dstXSize;
+
+		        int iXBlockOff = iSrcX % srcXBlockSize;
                         int iYBlockOff = iSrcY % srcYBlockSize;
                         int iBlockOff = (iXBlockOff + iYBlockOff * srcXBlockSize) * srcDataSize;
 
                         int iDstOff = (iDstY * dstXSize + iDstX) * dataSize;
 			if(supportedDataType) {
-				memcpy((uint8_t *)*dstBuf + iDstOff, (uint8_t *)blockList[iBlock] + iBlockOff, dataSize);
+				memcpy(pDstBuf + iDstOff, blockBuffer + iBlockOff, dataSize);
 			} else {
-				GDALCopyWords((uint8_t *)blockList[iBlock] + iBlockOff, srcDataType, srcDataSize, (uint8_t *)*dstBuf + iDstOff, *dType, dataSize, 1);
+				GDALCopyWords(blockBuffer + iBlockOff, srcDataType, srcDataSize, pDstBuf + iDstOff, *dType, dataSize, 1);
 			}
-                }
-        }
+
+		}
+	}
 
 	*bytesRead = srcXBlockSize * srcYBlockSize * srcDataSize * nBlocksRead;
 
@@ -381,17 +371,7 @@ int warp_operation_fast(const char *srcFilePath, char *srcProjRef, double *srcGe
 		}
 	}
 
-	if(blockList) {
-		int iBlock;
-		int nBlocks = bCache > 0 ? nXBlocks * nYBlocks : 1;
-		for(iBlock = 0; iBlock < nBlocks; iBlock++) {
-			if(blockList[iBlock]) {
-				free(blockList[iBlock]);
-			}
-		}
-
-		free(blockList);
-	}
+	free(blockBuffer);
         free(dx);
         free(dy);
         free(dz);
@@ -406,4 +386,3 @@ int warp_operation_fast(const char *srcFilePath, char *srcProjRef, double *srcGe
 	GDALClose(hSrcDS);
 	return 0;
 }
-


### PR DESCRIPTION
This PR reduces memory footprint for the warper. Now the memory consumption for GDAL read is at most one block of the data file.