### PR TITLE
added interpolation of 1D variables

### DIFF
--- a/libs/gdal/frmts/gsky_netcdf/netcdfdataset.cpp
+++ b/libs/gdal/frmts/gsky_netcdf/netcdfdataset.cpp
@@ -9940,7 +9940,7 @@ static CPLErr NCDFGet1DVar( int nCdfId, int nVarId, char **pszValue, size_t inte
                 start[0] = iStart;
                 nc_get_vara_double(nCdfId, nVarId, start, count, &pdfTemp[iStart]);
 
-                double slope = (pdfTemp[iStart] - pdfTemp[iPrev]) / (iStart - iPrev); 
+                double slope = (pdfTemp[iStart] - pdfTemp[iPrev]) / (iStart - iPrev);
                 size_t ss = 1;
                 for( size_t s = iPrev + 1; s < iStart; s++, ss++)
                 {


### PR DESCRIPTION
This PR addes interpolation of  large 1D variables instead of loading all its values. The interpolation is specified by `-oo interp_1d_var=<max element threshold>`.