### PR TITLE
fixed GDAL axis order incompatibility

### DIFF
--- a/worker/gdalprocess/drill.go
+++ b/worker/gdalprocess/drill.go
@@ -358,6 +358,7 @@ func getDrillFileDescriptor(ds C.GDALDatasetH, g C.OGRGeometryH, rasterXSize flo
 		srcSRS := C.OSRNewSpatialReference(cWGS84WKT)
 		defer C.OSRDestroySpatialReference(srcSRS)
 		C.OSRSetAxisMappingStrategy(srcSRS, C.OAMS_TRADITIONAL_GIS_ORDER)
+		C.OSRSetAxisMappingStrategy(desSRS, C.OAMS_TRADITIONAL_GIS_ORDER)
 		trans := C.OCTNewCoordinateTransformation(srcSRS, desSRS)
 		C.OGR_G_Transform(gCopy, trans)
 		C.OCTDestroyCoordinateTransformation(trans)


### PR DESCRIPTION
This PR fixes GDAL axis order incompatibility documented here https://gdal.org/tutorials/osr_api_tut.html#crs-and-axis-order. This PR also addresses https://github.com/nci/gsky/issues/534.